### PR TITLE
Update number of Gibbs sampling iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The number of threads can be given using `-t`.
 #### Inference models:
 The method currently contains four different inference models. Each model have been written with a particurlar path type and corresponding inference problem in mind:
 
-* `haplotypes`: Infers haplotype/diplotype/... posterior probabilities. By default it uses a Gibbs sampling scheme to infer the probabilities, however exact inference can be enabled using `-j`. The exact inference scales exponentially in the sample ploidy and it is therefore only recommended for when the number of haplotypes are low or the ploidy is 1. The ploidy can be given using `-y`.
+* `haplotypes`: Infers haplotype/diplotype/... posterior probabilities. By default it uses a Gibbs sampling scheme to infer the probabilities, however exact inference can be enabled using `-j`. The exact inference scales exponentially in the sample ploidy and it is therefore only recommended for when the number of haplotypes are low or the ploidy is 1 or 2. The ploidy can be given using `-y`.
 
 * `transcripts`: Infers abundances using a Expectation Maximization (EM) algorithm.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@
 #include "path_estimates_writer.hpp"
 
 const uint32_t align_path_buffer_size = 10000;
-const uint32_t read_path_cluster_probs_buffer_size = 100;
+const uint32_t read_path_cluster_probs_buffer_size = 10;
 const double prob_precision = pow(10, -8);
 
 typedef spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> align_paths_index_t;
@@ -226,7 +226,7 @@ int main(int argc, char* argv[]) {
     options.add_options("Abundance")
       ("y,ploidy", "sample ploidy", cxxopts::value<uint32_t>()->default_value("2"))
       ("j,use-exact", "use slower exact likelihood inference for haplotyping", cxxopts::value<bool>())
-      ("n,num-hap-its", "number of haplotyping iterations", cxxopts::value<uint32_t>()->default_value("1000"))
+      ("n,num-hap-its", "number of haplotyping iterations in haplotype-transcript inference", cxxopts::value<uint32_t>()->default_value("1000"))
       ("e,max-em-its", "maximum number of EM iterations", cxxopts::value<uint32_t>()->default_value("10000"))
       ("c,min-em-conv", "minimum abundance value used for EM convergence", cxxopts::value<double>()->default_value("0.01"))
       ("f,path-origin", "path transcript origin filename (required for haplotype-transcript inference)", cxxopts::value<string>())
@@ -459,7 +459,7 @@ int main(int argc, char* argv[]) {
 
     if (inference_model == "haplotypes") {
 
-        path_estimator = new PathGroupPosteriorEstimator(option_results["num-hap-its"].as<uint32_t>(), ploidy, option_results.count("use-exact"), rng_seed, prob_precision);
+        path_estimator = new PathGroupPosteriorEstimator(ploidy, option_results.count("use-exact"), rng_seed, prob_precision);
 
     } else if (inference_model == "transcripts") {
 

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -79,23 +79,6 @@ void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cl
 
         prev_abundances = path_cluster_estimates->abundances;
     }
-
-    double abundances_sum = 0;
-
-    for (size_t i = 0; i < path_cluster_estimates->abundances.cols(); ++i) {
-
-        if (path_cluster_estimates->abundances(0, i) < min_abundances) {
-
-            path_cluster_estimates->posteriors(0, i) = 0;
-            path_cluster_estimates->abundances(0, i) = 0;            
-        
-        } else {
-
-            abundances_sum += path_cluster_estimates->abundances(0, i);
-        }
-    }
-
-    path_cluster_estimates->abundances = path_cluster_estimates->abundances / abundances_sum;
 }
 
 void PathAbundanceEstimator::removeNoiseAndRenormalizeAbundances(PathClusterEstimates * path_cluster_estimates) const {
@@ -307,7 +290,7 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
 
             } else {
 
-                estimatePathGroupPosteriorsGibbs(&group_path_cluster_estimates, group_read_path_probs, group_noise_probs, group_read_counts, ploidy, num_nested_its, &mt_rng);
+                estimatePathGroupPosteriorsGibbs(&group_path_cluster_estimates, group_read_path_probs, group_noise_probs, group_read_counts, ploidy, &mt_rng);
             }
 
             samplePloidyPathIndices(&ploidy_path_indices_samples, group_path_cluster_estimates, group);

--- a/src/path_estimator.cpp
+++ b/src/path_estimator.cpp
@@ -1,6 +1,8 @@
 
 #include "path_estimator.hpp"
 
+static const uint32_t burn_it_scaling = 50;
+static const uint32_t gibbs_it_scaling = 5000; 
 
 bool probabilityCountRowSorter(const pair<Eigen::RowVectorXd, uint32_t> & lhs, const pair<Eigen::RowVectorXd, uint32_t> & rhs) { 
 
@@ -281,7 +283,7 @@ void PathEstimator::calculatePathGroupPosteriors(PathClusterEstimates * path_clu
     }
 }
 
-void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size, const uint32_t num_gibbs_its, mt19937 * mt_rng) {
+void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size, mt19937 * mt_rng) {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -313,7 +315,8 @@ void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path
 
     vector<uint32_t> path_group_sample_counts;
 
-    uint32_t num_burn_its = 10 * (group_size - 1);
+    const uint32_t num_burn_its = burn_it_scaling * group_size;
+    const uint32_t num_gibbs_its = gibbs_it_scaling * group_size;
 
     for (uint32_t i = 0; i < num_burn_its + num_gibbs_its; ++i) {
 

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -33,7 +33,7 @@ class PathEstimator {
         void collapseProbabilityMatrixPaths(Eigen::ColMatrixXd * read_path_probs);
 
         void calculatePathGroupPosteriors(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size);
-        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size, const uint32_t num_gibbs_its, mt19937 * mt_rng);
+        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size, mt19937 * mt_rng);
 
     private:
 

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -29,7 +29,7 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
     }
 }
 
-PathGroupPosteriorEstimator::PathGroupPosteriorEstimator(const uint32_t num_gibbs_its_in, const uint32_t ploidy_in, const bool use_exact_in, const uint32_t rng_seed, const double prob_precision) : num_gibbs_its(num_gibbs_its_in), ploidy(ploidy_in), use_exact(use_exact_in), PathPosteriorEstimator(prob_precision) {
+PathGroupPosteriorEstimator::PathGroupPosteriorEstimator(const uint32_t ploidy_in, const bool use_exact_in, const uint32_t rng_seed, const double prob_precision) : ploidy(ploidy_in), use_exact(use_exact_in), PathPosteriorEstimator(prob_precision) {
 
     mt_rng = mt19937(rng_seed);
 }
@@ -53,7 +53,7 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
         
         } else {
 
-            estimatePathGroupPosteriorsGibbs(path_cluster_estimates, read_path_probs, noise_probs, read_counts, ploidy, num_gibbs_its, &mt_rng);
+            estimatePathGroupPosteriorsGibbs(path_cluster_estimates, read_path_probs, noise_probs, read_counts, ploidy, &mt_rng);
         }
 
         assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->path_groups.size());

--- a/src/path_posterior_estimator.hpp
+++ b/src/path_posterior_estimator.hpp
@@ -30,14 +30,13 @@ class PathGroupPosteriorEstimator : public PathPosteriorEstimator {
 
     public:
 
-        PathGroupPosteriorEstimator(const uint32_t num_gibbs_its_in, const uint32_t ploidy_in, const bool use_exact_in, const uint32_t rng_seed, const double prob_precision);
+        PathGroupPosteriorEstimator(const uint32_t ploidy_in, const bool use_exact_in, const uint32_t rng_seed, const double prob_precision);
         ~PathGroupPosteriorEstimator() {};
 
         void estimate(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs);
 
     private: 
 
-        const uint32_t num_gibbs_its;
         const uint32_t ploidy;
         const bool use_exact;
 

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -67,21 +67,19 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             for (auto path_id: align_paths_ids.at(i)) {
 
                 auto clustered_path_index_it = clustered_path_index.find(path_id);
+                assert(clustered_path_index_it != clustered_path_index.end());
 
-                if (clustered_path_index_it != clustered_path_index.end()) {
+                uint32_t path_idx = clustered_path_index_it->second;
 
-                    uint32_t path_idx = clustered_path_index_it->second;
+                if (doubleCompare(cluster_paths.at(path_idx).effective_length, 0)) {
 
-                    if (doubleCompare(cluster_paths.at(path_idx).effective_length, 0)) {
+                    assert(doubleCompare(read_path_log_probs.at(path_idx), numeric_limits<double>::lowest()));
+                    read_path_log_probs.at(path_idx) = numeric_limits<double>::lowest();
 
-                        assert(doubleCompare(read_path_log_probs.at(path_idx), numeric_limits<double>::lowest()));
-                        read_path_log_probs.at(path_idx) = numeric_limits<double>::lowest();
+                } else {
 
-                    } else {
-
-                        // account for really rare cases when a mpmap alignment can have multiple alignments on the same path
-                        read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), align_paths_log_probs.at(i) - log(cluster_paths.at(path_idx).effective_length));
-                    }
+                    // account for really rare cases when a mpmap alignment can have multiple alignments on the same path
+                    read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), align_paths_log_probs.at(i) - log(cluster_paths.at(path_idx).effective_length));
                 }
             }
         }


### PR DESCRIPTION
* The number of Gibbs sampling iterations are now independent of the number of haplotyping iterations in the *haplotype-transcripts* inference model. 
* The haplotype posterior values in the output are also now independent of the expression values.