### PR TITLE
Major update (includes multi-mapping support and reduced memory usage)

### DIFF
--- a/src/alignment_path.cpp
+++ b/src/alignment_path.cpp
@@ -4,11 +4,11 @@
 #include <algorithm>
 #include <numeric>
 
-AlignmentPath::AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const gbwt::SearchState & search_state_in) : seq_length(seq_length_in), mapq_comb(mapq_comb_in), score_sum(score_sum_in), search_state(search_state_in) {}
+AlignmentPath::AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool has_multi_start_in, const gbwt::SearchState & search_state_in) : seq_length(seq_length_in), mapq_comb(mapq_comb_in), has_multi_start(has_multi_start_in), score_sum(score_sum_in), search_state(search_state_in) {}
 
-AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in) : seq_length(align_path_in.seq_length), mapq_comb(align_path_in.mapqComb()), score_sum(align_path_in.scoreSum()), search_state(align_path_in.search_state) {}
+AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bool has_multi_start_in) : seq_length(align_path_in.seq_length), mapq_comb(align_path_in.mapqComb()), score_sum(align_path_in.scoreSum()), search_state(align_path_in.search_state), has_multi_start(has_multi_start_in) {}
 
-vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths) {
+vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool has_multi_start) {
 
     vector<AlignmentPath> align_paths;
     align_paths.reserve(align_search_paths.size());
@@ -17,7 +17,7 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
 
         if (align_search_path.complete()) {
 
-            align_paths.emplace_back(align_search_path);
+            align_paths.emplace_back(align_search_path, has_multi_start);
         }
     }
 
@@ -26,7 +26,7 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
 
 bool operator==(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
 
-    return (lhs.seq_length == rhs.seq_length && lhs.mapq_comb == rhs.mapq_comb && lhs.score_sum == rhs.score_sum && lhs.search_state == rhs.search_state);
+    return (lhs.seq_length == rhs.seq_length && lhs.mapq_comb == rhs.mapq_comb && lhs.score_sum == rhs.score_sum && lhs.has_multi_start == rhs.has_multi_start && lhs.search_state == rhs.search_state);
 }
 
 bool operator!=(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
@@ -51,6 +51,11 @@ bool operator<(const AlignmentPath & lhs, const AlignmentPath & rhs) {
         return (lhs.score_sum < rhs.score_sum);    
     } 
 
+    if (lhs.has_multi_start != rhs.has_multi_start) {
+
+        return (lhs.has_multi_start < rhs.has_multi_start);    
+    } 
+
     if (lhs.search_state.node != rhs.search_state.node) {
 
         return (lhs.search_state.node < rhs.search_state.node);    
@@ -69,6 +74,7 @@ ostream & operator<<(ostream & os, const AlignmentPath & align_path) {
     os << align_path.seq_length;
     os << " | " << align_path.mapq_comb;
     os << " | " << align_path.score_sum;
+    os << " | " << align_path.has_multi_start;
     os << " | " << gbwt::Node::id(align_path.search_state.node);
     os << " | " << align_path.search_state.range.first << " " << align_path.search_state.range.second;
 

--- a/src/alignment_path.cpp
+++ b/src/alignment_path.cpp
@@ -4,11 +4,11 @@
 #include <algorithm>
 #include <numeric>
 
-AlignmentPath::AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool has_multi_start_in, const gbwt::SearchState & search_state_in) : seq_length(seq_length_in), mapq_comb(mapq_comb_in), has_multi_start(has_multi_start_in), score_sum(score_sum_in), search_state(search_state_in) {}
+AlignmentPath::AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool is_multimap_in, const gbwt::SearchState & search_state_in) : seq_length(seq_length_in), mapq_comb(mapq_comb_in), is_multimap(is_multimap_in), score_sum(score_sum_in), search_state(search_state_in) {}
 
-AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bool has_multi_start_in) : seq_length(align_path_in.seq_length), mapq_comb(align_path_in.mapqComb()), score_sum(align_path_in.scoreSum()), search_state(align_path_in.search_state), has_multi_start(has_multi_start_in) {}
+AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bool is_multimap_in) : seq_length(align_path_in.seq_length), mapq_comb(align_path_in.mapqComb()), score_sum(align_path_in.scoreSum()), search_state(align_path_in.search_state), is_multimap(is_multimap_in) {}
 
-vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool has_multi_start) {
+vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool is_multimap) {
 
     vector<AlignmentPath> align_paths;
     align_paths.reserve(align_search_paths.size());
@@ -17,7 +17,7 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
 
         if (align_search_path.complete()) {
 
-            align_paths.emplace_back(align_search_path, has_multi_start);
+            align_paths.emplace_back(align_search_path, is_multimap);
         }
     }
 
@@ -26,7 +26,7 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
 
 bool operator==(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
 
-    return (lhs.seq_length == rhs.seq_length && lhs.mapq_comb == rhs.mapq_comb && lhs.score_sum == rhs.score_sum && lhs.has_multi_start == rhs.has_multi_start && lhs.search_state == rhs.search_state);
+    return (lhs.seq_length == rhs.seq_length && lhs.mapq_comb == rhs.mapq_comb && lhs.score_sum == rhs.score_sum && lhs.is_multimap == rhs.is_multimap && lhs.search_state == rhs.search_state);
 }
 
 bool operator!=(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
@@ -51,9 +51,9 @@ bool operator<(const AlignmentPath & lhs, const AlignmentPath & rhs) {
         return (lhs.score_sum < rhs.score_sum);    
     } 
 
-    if (lhs.has_multi_start != rhs.has_multi_start) {
+    if (lhs.is_multimap != rhs.is_multimap) {
 
-        return (lhs.has_multi_start < rhs.has_multi_start);    
+        return (lhs.is_multimap < rhs.is_multimap);    
     } 
 
     if (lhs.search_state.node != rhs.search_state.node) {
@@ -74,7 +74,7 @@ ostream & operator<<(ostream & os, const AlignmentPath & align_path) {
     os << align_path.seq_length;
     os << " | " << align_path.mapq_comb;
     os << " | " << align_path.score_sum;
-    os << " | " << align_path.has_multi_start;
+    os << " | " << align_path.is_multimap;
     os << " | " << gbwt::Node::id(align_path.search_state.node);
     os << " | " << align_path.search_state.range.first << " " << align_path.search_state.range.second;
 

--- a/src/alignment_path.hpp
+++ b/src/alignment_path.hpp
@@ -20,16 +20,17 @@ class AlignmentPath {
 
     public: 
         
-        AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const gbwt::SearchState & search_state_in);
-        AlignmentPath(const AlignmentSearchPath & align_path_in);
+        AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool has_multi_start_in, const gbwt::SearchState & search_state_in);
+        AlignmentPath(const AlignmentSearchPath & align_path_in, const bool has_multi_start_in);
 
         uint32_t seq_length;
         uint32_t mapq_comb;
         uint32_t score_sum;
 
+        bool has_multi_start;
         gbwt::SearchState search_state;
 
-        static vector<AlignmentPath> alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths);
+        static vector<AlignmentPath> alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool has_multi_start);
 };
 
 bool operator==(const AlignmentPath & lhs, const AlignmentPath & rhs);
@@ -53,6 +54,7 @@ namespace std {
                 spp::hash_combine(seed, align_path.seq_length);
                 spp::hash_combine(seed, align_path.mapq_comb);
                 spp::hash_combine(seed, align_path.score_sum);
+                spp::hash_combine(seed, align_path.has_multi_start);
                 spp::hash_combine(seed, align_path.search_state.node);
                 spp::hash_combine(seed, align_path.search_state.range.first);
                 spp::hash_combine(seed, align_path.search_state.range.second);

--- a/src/alignment_path.hpp
+++ b/src/alignment_path.hpp
@@ -20,17 +20,17 @@ class AlignmentPath {
 
     public: 
         
-        AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool has_multi_start_in, const gbwt::SearchState & search_state_in);
-        AlignmentPath(const AlignmentSearchPath & align_path_in, const bool has_multi_start_in);
+        AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool is_multimap_in, const gbwt::SearchState & search_state_in);
+        AlignmentPath(const AlignmentSearchPath & align_path_in, const bool is_multimap_in);
 
         uint32_t seq_length;
         uint32_t mapq_comb;
         uint32_t score_sum;
 
-        bool has_multi_start;
+        bool is_multimap;
         gbwt::SearchState search_state;
 
-        static vector<AlignmentPath> alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool has_multi_start);
+        static vector<AlignmentPath> alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool is_multimap);
 };
 
 bool operator==(const AlignmentPath & lhs, const AlignmentPath & rhs);
@@ -54,7 +54,7 @@ namespace std {
                 spp::hash_combine(seed, align_path.seq_length);
                 spp::hash_combine(seed, align_path.mapq_comb);
                 spp::hash_combine(seed, align_path.score_sum);
-                spp::hash_combine(seed, align_path.has_multi_start);
+                spp::hash_combine(seed, align_path.is_multimap);
                 spp::hash_combine(seed, align_path.search_state.node);
                 spp::hash_combine(seed, align_path.search_state.range.first);
                 spp::hash_combine(seed, align_path.search_state.range.second);

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -78,7 +78,7 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
         align_search_paths.insert(align_search_paths.end(), align_search_paths_rc.begin(), align_search_paths_rc.end());
     }  
 
-    auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths, getAlignmentStartNodesIndex(alignment).size() > 0);
+    auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths, isAlignmentDisconnected(alignment));
 
 #ifdef debug
 
@@ -287,7 +287,7 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPat
         pairAlignmentPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
     }
 
-    auto paired_align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(paired_align_search_paths, (getAlignmentStartNodesIndex(alignment_1).size() > 0) || (getAlignmentStartNodesIndex(alignment_2).size() > 0));
+    auto paired_align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(paired_align_search_paths, isAlignmentDisconnected(alignment_1) || isAlignmentDisconnected(alignment_2));
 
 #ifdef debug
 
@@ -488,6 +488,31 @@ multimap<gbwt::node_type, uint32_t> AlignmentPathFinder<AlignmentType>::getAlign
     }
 
     return alignment_start_nodes_index;
+}
+
+template<class AlignmentType>
+bool AlignmentPathFinder<AlignmentType>::isAlignmentDisconnected(const vg::Alignment & alignment) const {
+
+    return false;
+}
+
+template<class AlignmentType>
+bool AlignmentPathFinder<AlignmentType>::isAlignmentDisconnected(const vg::MultipathAlignment & alignment) const {
+
+    bool is_connected = false;
+
+    if (alignment.has_annotation()) {
+
+        auto annotation_it = alignment.annotation().fields().find("disconnected");
+
+        if (annotation_it != alignment.annotation().fields().end()) {
+
+            assert(annotation_it->second.bool_value());
+            is_connected = true;
+        }
+    }
+
+    return is_connected;
 }
 
 template class AlignmentPathFinder<vg::Alignment>;

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -78,7 +78,7 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
         align_search_paths.insert(align_search_paths.end(), align_search_paths_rc.begin(), align_search_paths_rc.end());
     }  
 
-    auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths);
+    auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths, getAlignmentStartNodesIndex(alignment).size() > 0);
 
 #ifdef debug
 
@@ -287,7 +287,7 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPat
         pairAlignmentPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
     }
 
-    auto paired_align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(paired_align_search_paths);
+    auto paired_align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(paired_align_search_paths, (getAlignmentStartNodesIndex(alignment_1).size() > 0) || (getAlignmentStartNodesIndex(alignment_2).size() > 0));
 
 #ifdef debug
 

--- a/src/alignment_path_finder.hpp
+++ b/src/alignment_path_finder.hpp
@@ -45,6 +45,9 @@ class AlignmentPathFinder {
 
 		multimap<gbwt::node_type, uint32_t> getAlignmentStartNodesIndex(const vg::Alignment & alignment) const;
 		multimap<gbwt::node_type, uint32_t> getAlignmentStartNodesIndex(const vg::MultipathAlignment & alignment) const;
+
+		bool isAlignmentDisconnected(const vg::Alignment & alignment) const;
+		bool isAlignmentDisconnected(const vg::MultipathAlignment & alignment) const;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main(int argc, char* argv[]) {
     options.add_options("Probability")
       ("m,frag-mean", "mean for fragment length distribution", cxxopts::value<double>())
       ("d,frag-sd", "standard deviation for fragment length distribution", cxxopts::value<double>())
-      ("q,filt-mapq-prob", "filter alignments with a mapq error probability above value", cxxopts::value<double>()->default_value("0.002"))
+      ("q,filt-mapq-prob", "filter alignments with a mapq error probability above value", cxxopts::value<double>()->default_value("0.01"))
       ("b,prob-output", "write read path probabilities to file", cxxopts::value<string>())
       ;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,6 +526,8 @@ int main(int argc, char* argv[]) {
 
         auto align_paths_cluster_idx = align_paths_clusters_indices.at(i).second;
 
+        // cerr << "DEBUG: Start " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
+
         auto * read_path_cluster_probs_buffer = &(threaded_read_path_cluster_probs_buffer.at(omp_get_thread_num()));
 
         read_path_cluster_probs_buffer->emplace_back(vector<ReadPathProbabilities>());            
@@ -537,7 +539,9 @@ int main(int argc, char* argv[]) {
         path_cluster_estimates->emplace_back(PathClusterEstimates());
 
         path_cluster_estimates->back().paths.reserve(path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size());
-        
+    
+        // cerr << "DEBUG: Path info " << i << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
+    
         for (auto & path_id: path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx)) {
 
             assert(clustered_path_index.emplace(path_id, clustered_path_index.size()).second);
@@ -566,6 +570,8 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // cerr << "DEBUG: Probs calc " << i << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
+
         for (auto & align_paths: align_paths_clusters.at(align_paths_cluster_idx)) {
 
             vector<vector<gbwt::size_type> > align_paths_ids;
@@ -581,8 +587,12 @@ int main(int argc, char* argv[]) {
         }
 
         sort(read_path_cluster_probs_buffer->back().begin(), read_path_cluster_probs_buffer->back().end());
-        
+      
+        // cerr << "DEBUG: Estimate " << i << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
+  
         path_estimator->estimate(&(path_cluster_estimates->back()), read_path_cluster_probs_buffer->back());
+
+        // cerr << "DEBUG: Probs out " << i << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
 
         if (prob_matrix_writer) {
 
@@ -609,6 +619,8 @@ int main(int argc, char* argv[]) {
 
             read_path_cluster_probs_buffer->clear();
         }
+
+        // cerr << "DEBUG: End " << i << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
     }
 
     if (prob_matrix_writer) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,7 +526,7 @@ int main(int argc, char* argv[]) {
 
         auto align_paths_cluster_idx = align_paths_clusters_indices.at(i).second;
 
-        if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 100 || align_paths_clusters.at(align_paths_cluster_idx).size()) {
+        if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
 
             #pragma omp critical
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,7 +440,11 @@ int main(int argc, char* argv[]) {
     cerr << "Found alignment paths (" << time3 - time2 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
 
     PathClusters path_clusters(paths_index, num_threads);
+
+    cerr << path_clusters.cluster_to_paths_index.size() << endl;
     path_clusters.addReadClusters(align_paths_index);
+
+    cerr << path_clusters.cluster_to_paths_index.size() << endl;
 
     double time6 = gbwt::readTimer();
     cerr << "Created alignment path clusters (" << time6 - time3 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,12 +234,12 @@ int main(int argc, char* argv[]) {
     options.add_options("Probability")
       ("m,frag-mean", "mean for fragment length distribution", cxxopts::value<double>())
       ("d,frag-sd", "standard deviation for fragment length distribution", cxxopts::value<double>())
-      ("q,filt-mapq-prob", "filter alignments with a mapq error probability above value", cxxopts::value<double>()->default_value("0.01"))
+      ("q,filt-mapq-prob", "filter alignments with a mapq error probability above value", cxxopts::value<double>()->default_value("1"))
       ("b,prob-output", "write read path probabilities to file", cxxopts::value<string>())
       ;
 
     options.add_options("Abundance")
-      ("y,ploidy", "sample ploidy", cxxopts::value<uint32_t>()->default_value("2"))
+      ("y,ploidy", "max sample ploidy", cxxopts::value<uint32_t>()->default_value("2"))
       ("j,use-exact", "use slower exact likelihood inference for haplotyping", cxxopts::value<bool>())
       ("n,num-hap-its", "number of haplotyping iterations in haplotype-transcript inference", cxxopts::value<uint32_t>()->default_value("1000"))
       ("e,max-em-its", "maximum number of EM iterations", cxxopts::value<uint32_t>()->default_value("10000"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,6 @@
 
 const uint32_t align_paths_buffer_size = 10000;
 const uint32_t read_path_cluster_probs_buffer_size = 10;
-const double prob_precision = pow(10, -8);
 
 typedef spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> align_paths_index_t;
 typedef spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > connected_align_paths_t;
@@ -235,6 +234,7 @@ int main(int argc, char* argv[]) {
       ("m,frag-mean", "mean for fragment length distribution", cxxopts::value<double>())
       ("d,frag-sd", "standard deviation for fragment length distribution", cxxopts::value<double>())
       ("q,filt-mapq-prob", "filter alignments with a mapq error probability above value", cxxopts::value<double>()->default_value("1"))
+      ("k,prob-precision", "precision threshold used to collapse similar probabilities and filter output", cxxopts::value<double>()->default_value("1e-8"))
       ("b,prob-output", "write read path probabilities to file", cxxopts::value<string>())
       ;
 
@@ -463,6 +463,8 @@ int main(int argc, char* argv[]) {
     double time7 = gbwt::readTimer();
     cerr << "Clustered alignment paths (" << time7 - time6 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
 
+    const double prob_precision = option_results["prob-precision"].as<double>();
+
     ProbabilityMatrixWriter * prob_matrix_writer = nullptr;
 
     spp::sparse_hash_map<string, pair<string, uint32_t> > haplotype_transcript_info;
@@ -671,7 +673,7 @@ int main(int argc, char* argv[]) {
 
     if (inference_model == "haplotypes") {
 
-        path_estimates_writer.writeThreadedPathClusterPosteriors(threaded_path_cluster_estimates, ploidy); 
+        path_estimates_writer.writeThreadedPathClusterPosteriors(threaded_path_cluster_estimates, ploidy, prob_precision); 
 
     } else {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,11 +443,7 @@ int main(int argc, char* argv[]) {
     cerr << "Found alignment paths (" << time3 - time2 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
 
     PathClusters path_clusters(paths_index, num_threads);
-
-    cerr << path_clusters.cluster_to_paths_index.size() << endl;
     path_clusters.addReadClusters(align_paths_index);
-
-    cerr << path_clusters.cluster_to_paths_index.size() << endl;
 
     double time6 = gbwt::readTimer();
     cerr << "Created alignment path clusters (" << time6 - time3 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
@@ -526,16 +522,16 @@ int main(int argc, char* argv[]) {
 
         auto align_paths_cluster_idx = align_paths_clusters_indices.at(i).second;
 
-        double debug_time = gbwt::readTimer();
+        // double debug_time = gbwt::readTimer();
 
-        if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
+        // if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
 
-            #pragma omp critical
-            {
+        //     #pragma omp critical
+        //     {
                 
-                cerr << "DEBUG: Start " << omp_get_thread_num() << ": " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
-            }
-        }
+        //         cerr << "DEBUG: Start " << omp_get_thread_num() << ": " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
+        //     }
+        // }
 
         auto * read_path_cluster_probs_buffer = &(threaded_read_path_cluster_probs_buffer.at(omp_get_thread_num()));
 
@@ -643,14 +639,14 @@ int main(int argc, char* argv[]) {
             read_path_cluster_probs_buffer->clear();
         }
 
-        if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
+        // if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
 
-            #pragma omp critical
-            {
+        //     #pragma omp critical
+        //     {
                 
-                cerr << "DEBUG: End " << omp_get_thread_num() << ": " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << " " << gbwt::readTimer() - debug_time << endl;
-            }
-        }
+        //         cerr << "DEBUG: End " << omp_get_thread_num() << ": " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << " " << gbwt::readTimer() - debug_time << endl;
+        //     }
+        // }
     }
 
     if (prob_matrix_writer) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -439,8 +439,8 @@ int main(int argc, char* argv[]) {
     double time3 = gbwt::readTimer();
     cerr << "Found alignment paths (" << time3 - time2 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
 
-    PathClusters path_clusters(num_threads);
-    auto node_to_path_index = path_clusters.findPathNodeClusters(paths_index);
+    PathClusters path_clusters(paths_index, num_threads);
+    path_clusters.addReadClusters(align_paths_index);
 
     double time6 = gbwt::readTimer();
     cerr << "Created alignment path clusters (" << time6 - time3 << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
@@ -453,7 +453,7 @@ int main(int argc, char* argv[]) {
 
         auto node_id = gbwt::Node::id(align_paths_index_it->first.front().search_state.node);
 
-        align_paths_clusters.at(path_clusters.path_to_cluster_index.at(node_to_path_index.at(node_id))).emplace_back(align_paths_index_it);
+        align_paths_clusters.at(path_clusters.path_to_cluster_index.at(path_clusters.node_to_path_index.at(node_id))).emplace_back(align_paths_index_it);
         ++align_paths_index_it;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -526,6 +526,8 @@ int main(int argc, char* argv[]) {
 
         auto align_paths_cluster_idx = align_paths_clusters_indices.at(i).second;
 
+        double debug_time = gbwt::readTimer();
+
         if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
 
             #pragma omp critical
@@ -639,6 +641,15 @@ int main(int argc, char* argv[]) {
         } else {
 
             read_path_cluster_probs_buffer->clear();
+        }
+
+        if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {
+
+            #pragma omp critical
+            {
+                
+                cerr << "DEBUG: End " << omp_get_thread_num() << ": " << i << " " << path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() << " " << align_paths_clusters.at(align_paths_cluster_idx).size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << " " << gbwt::readTimer() - debug_time << endl;
+            }
         }
     }
 

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -292,10 +292,8 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
                 group_path_counts.emplace_back(path_cluster_estimates->paths.at(group.at(i)).count);
             }
 
-            addNoiseAndNormalizeProbabilityMatrix(&group_read_path_probs, noise_probs);
-
-            // group_read_path_probs->conservativeResize(group_read_path_probs->rows(), group_read_path_probs->cols() + 1);
-            // group_read_path_probs->col(group_read_path_probs->cols() - 1) = noise_probs;
+            group_read_path_probs.conservativeResize(group_read_path_probs.rows(), group_read_path_probs.cols() + 1);
+            group_read_path_probs.col(group_read_path_probs.cols() - 1) = noise_probs;
 
             Eigen::RowVectorXui group_read_counts = read_counts;
             collapseProbabilityMatrixReads(&group_read_path_probs, &group_read_counts);

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -277,8 +277,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
             path_indices_samples.reserve(path_groups.size() * ploidy);
         }
 
-        cerr << "\tDEBUG: Group start " << omp_get_thread_num() << ": " << path_groups.size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
-
         for (auto & group: path_groups) {    
 
             Eigen::ColMatrixXd group_read_path_probs;
@@ -286,21 +284,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
             Eigen::RowVectorXui group_read_counts;        
 
             constructProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group);
-
-            double num_zeros = 0;
-
-            for (size_t i = 0; i < group_read_path_probs.rows(); ++i) {
-
-                for (size_t j = 0; j < group_read_path_probs.cols(); ++j) {
-
-                    if (doubleCompare(group_read_path_probs(i, j), 0)) {
-
-                        num_zeros++;
-                    }
-                }
-            }
-
-            cerr << "\tDEBUG: Zero " << omp_get_thread_num() << ": " << num_zeros / static_cast<double>(group_read_path_probs.rows() * group_read_path_probs.cols()) << " " << group_read_path_probs.cols() << " " << group_read_path_probs.rows() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
 
             vector<uint32_t> group_path_counts;
             group_path_counts.reserve(group.size());
@@ -324,8 +307,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
             samplePloidyPathIndices(&ploidy_path_indices_samples, group_path_cluster_estimates, group);
         }
 
-        cerr << "\tDEBUG: Group end " << omp_get_thread_num() << ": " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
-
         unordered_map<vector<uint32_t>, uint32_t> collapsed_ploidy_path_indices_samples;
 
         for (auto & path_samples: ploidy_path_indices_samples) {
@@ -337,8 +318,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
         }
 
         path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size() + 1, 0, true);
-
-        cerr << "\tDEBUG: EM start " << omp_get_thread_num() << ": " << collapsed_ploidy_path_indices_samples.size() << " " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
 
         bool is_first = true;
 
@@ -379,8 +358,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
         }
 
         removeNoiseAndRenormalizeAbundances(path_cluster_estimates);
-
-        cerr << "\tDEBUG: EM end " << omp_get_thread_num() << ": " << gbwt::inGigabytes(gbwt::memoryUsage()) << endl;
 
     } else {
 

--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -15,6 +15,7 @@ struct PathInfo {
         
     string name;
     string origin;
+    uint32_t count;
     uint32_t length;
     double effective_length;
     
@@ -22,6 +23,7 @@ struct PathInfo {
 
         name = "";
         origin = "";
+        count = 0;
         length = 0;
         effective_length = 0;
     }

--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -23,7 +23,7 @@ struct PathInfo {
 
         name = "";
         origin = "";
-        count = 0;
+        count = 1;
         length = 0;
         effective_length = 0;
     }

--- a/src/path_clusters.cpp
+++ b/src/path_clusters.cpp
@@ -46,10 +46,12 @@ PathClusters::PathClusters(const PathsIndex & paths_index_in, const uint32_t num
                     if (anchor_path_id != path_id) {
 
                         auto thread_connected_paths_it = thread_connected_paths.emplace(anchor_path_id, spp::sparse_hash_set<uint32_t>());
-                        thread_connected_paths_it.first->second.emplace(path_id);
+                        
+                        if (thread_connected_paths_it.first->second.emplace(path_id).second) {
 
-                        thread_connected_paths_it = thread_connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
-                        thread_connected_paths_it.first->second.emplace(anchor_path_id);
+                            thread_connected_paths_it = thread_connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
+                            thread_connected_paths_it.first->second.emplace(anchor_path_id);
+                        }
                     }
                 }
 
@@ -92,10 +94,18 @@ void PathClusters::addReadClusters(const spp::sparse_hash_map<vector<AlignmentPa
 
                 if (cur_align_paths_index_pos % num_threads == i) { 
 
+                    assert(!align_paths.first.empty());
+
+                    if (!align_paths.first.front().has_multi_start) {
+
+                        continue;
+                    }
+
                     auto anchor_path_id = 0;
 
                     for (size_t j = 0; j < align_paths.first.size(); ++j) {
 
+                        assert(align_paths.first.at(j).has_multi_start);
                         auto align_path_ids = paths_index.locatePathIds(align_paths.first.at(j).search_state);
 
                         if (j == 0) {
@@ -108,10 +118,12 @@ void PathClusters::addReadClusters(const spp::sparse_hash_map<vector<AlignmentPa
                             if (anchor_path_id != path_id) {
 
                                 auto thread_connected_paths_it = thread_connected_paths.emplace(anchor_path_id, spp::sparse_hash_set<uint32_t>());
-                                thread_connected_paths_it.first->second.emplace(path_id);
+                                
+                                if (thread_connected_paths_it.first->second.emplace(path_id).second) {
 
-                                thread_connected_paths_it = thread_connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
-                                thread_connected_paths_it.first->second.emplace(anchor_path_id);
+                                    thread_connected_paths_it = thread_connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
+                                    thread_connected_paths_it.first->second.emplace(anchor_path_id);
+                                }
                             }
                         }
                     }
@@ -171,10 +183,12 @@ void PathClusters::addCallTraversalClusters() {
             if (anchor_path_id != path_id) {
 
                 auto connected_paths_it = connected_paths.emplace(anchor_path_id, spp::sparse_hash_set<uint32_t>());
-                connected_paths_it.first->second.emplace(path_id);
+                
+                if (connected_paths_it.first->second.emplace(path_id).second) {
 
-                connected_paths_it = connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
-                connected_paths_it.first->second.emplace(anchor_path_id);
+                    connected_paths_it = connected_paths.emplace(path_id, spp::sparse_hash_set<uint32_t>());
+                    connected_paths_it.first->second.emplace(anchor_path_id);
+                }
             }
         }
     } 

--- a/src/path_clusters.cpp
+++ b/src/path_clusters.cpp
@@ -61,9 +61,6 @@ PathClusters::PathClusters(const PathsIndex & paths_index_in, const uint32_t num
 
         #pragma omp critical
         {
-
-            cerr << thread_connected_paths.size() << " " << thread_node_to_path_index.size() << endl;
-
             for (auto & paths: thread_connected_paths) {
 
                 auto connected_paths_it = connected_paths.emplace(paths.first, spp::sparse_hash_set<uint32_t>());
@@ -137,8 +134,6 @@ void PathClusters::addReadClusters(const spp::sparse_hash_map<vector<AlignmentPa
 
         #pragma omp critical
         {
-            cerr << num_multimap << " " << threaded_multimap_connected_clusters.size() << endl;
-
             for (auto & paths: threaded_multimap_connected_clusters) {
 
                 auto multimap_connected_clusters_it = multimap_connected_clusters.emplace(paths.first, spp::sparse_hash_set<uint32_t>());

--- a/src/path_clusters.hpp
+++ b/src/path_clusters.hpp
@@ -35,8 +35,9 @@ class PathClusters {
         const PathsIndex & paths_index;
         const uint32_t num_threads;
 
-        connected_paths_t findConnectedPaths() const;
     	void createPathClusters(const connected_paths_t & connected_paths);
+        void mergeClusters(const connected_paths_t & connected_clusters);
+
 };
 
 

--- a/src/path_clusters.hpp
+++ b/src/path_clusters.hpp
@@ -9,30 +9,34 @@
 #include "sparsepp/spp.h"
 
 #include "paths_index.hpp"
+#include "alignment_path.hpp"
 
 using namespace std;
 
+
+typedef spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > connected_paths_t;
 
 class PathClusters {
 
     public: 
 
-        PathClusters(const uint32_t num_threads_in);
+        PathClusters(const PathsIndex & paths_index_in, const uint32_t num_threads_in);
 
-    	void findPathClusters(spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > * connected_paths, const PathsIndex & paths_index);   
-    	void findPathClusters(vector<spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > > * connected_paths, const PathsIndex & paths_index);
+        void addReadClusters(const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index);
+    	void addCallTraversalClusters();
 
-        spp::sparse_hash_map<uint32_t, uint32_t> findPathNodeClusters(const PathsIndex & paths_index);
-    	void findCallTraversalClusters(const PathsIndex & paths_index);
+        spp::sparse_hash_map<uint32_t, uint32_t> node_to_path_index;
 
         vector<uint32_t> path_to_cluster_index;
         vector<vector<uint32_t> > cluster_to_paths_index;
 
     private: 
 
+        const PathsIndex & paths_index;
         const uint32_t num_threads;
 
-    	void createPathClusters(const spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > & connected_paths, const uint32_t num_paths);
+        connected_paths_t findConnectedPaths() const;
+    	void createPathClusters(const connected_paths_t & connected_paths);
 };
 
 

--- a/src/path_estimates_writer.cpp
+++ b/src/path_estimates_writer.cpp
@@ -33,7 +33,7 @@ PathEstimatesWriter::~PathEstimatesWriter() {
     }
 }
 
-void PathEstimatesWriter::writeThreadedPathClusterPosteriors(const vector<vector<PathClusterEstimates> > & threaded_path_cluster_estimates, const uint32_t ploidy) {
+void PathEstimatesWriter::writeThreadedPathClusterPosteriors(const vector<vector<PathClusterEstimates> > & threaded_path_cluster_estimates, const uint32_t ploidy, const double prob_precision) {
 
     for (uint32_t i = 0; i < ploidy; ++i) {
 
@@ -56,14 +56,17 @@ void PathEstimatesWriter::writeThreadedPathClusterPosteriors(const vector<vector
 
                 assert(path_cluster_estimates.path_groups.at(i).size() == ploidy);
 
-                for (auto & path_idx: path_cluster_estimates.path_groups.at(i)) {
+                if (path_cluster_estimates.posteriors(0, i) >= prob_precision) {
 
-                    *writer_stream << path_cluster_estimates.paths.at(path_idx).name << "\t";
+                    for (auto & path_idx: path_cluster_estimates.path_groups.at(i)) {
+
+                        *writer_stream << path_cluster_estimates.paths.at(path_idx).name << "\t";
+                    }
+
+                    *writer_stream << cluster_id;
+                    *writer_stream << "\t" << path_cluster_estimates.posteriors(0, i);
+                    *writer_stream << endl;
                 }
-
-                *writer_stream << cluster_id;
-                *writer_stream << "\t" << path_cluster_estimates.posteriors(0, i);
-                *writer_stream << endl;
             }
         }
     }

--- a/src/path_estimates_writer.hpp
+++ b/src/path_estimates_writer.hpp
@@ -20,7 +20,7 @@ class PathEstimatesWriter {
     	PathEstimatesWriter(const bool use_stdout_in, const string filename);
     	~PathEstimatesWriter();
 
-        void writeThreadedPathClusterPosteriors(const vector<vector<PathClusterEstimates> > & threaded_path_cluster_estimates, const uint32_t ploidy);
+        void writeThreadedPathClusterPosteriors(const vector<vector<PathClusterEstimates> > & threaded_path_cluster_estimates, const uint32_t ploidy, const double prob_precision);
         void writeThreadedPathClusterAbundances(const vector<vector<PathClusterEstimates> > & threaded_path_cluster_estimates);
 
     private:

--- a/src/path_estimator.cpp
+++ b/src/path_estimator.cpp
@@ -62,59 +62,18 @@ void PathEstimator::constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_pr
     *noise_probs = Eigen::ColVectorXd(cluster_probs.size());
     *read_counts = Eigen::RowVectorXui(cluster_probs.size());
 
-    uint32_t num_rows = 0;
-
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
         for (auto & prob: cluster_probs.at(i).probabilities()) {
 
             if (prob.first < path_id_idx.size() && path_id_idx.at(prob.first) >= 0) {
 
-                (*read_path_probs)(num_rows, path_id_idx.at(prob.first)) = prob.second;
+                (*read_path_probs)(i, path_id_idx.at(prob.first)) = prob.second;
             }
         }
 
-        (*noise_probs)(num_rows, 0) = cluster_probs.at(i).noiseProbability();
-        (*read_counts)(0, num_rows) = cluster_probs.at(i).readCount();
-
-        if (num_rows > 0) {
-
-            bool is_identical = true;
-
-            for (size_t j = 0; j < read_path_probs->cols(); ++j) {
-
-                if (abs((*read_path_probs)(num_rows - 1, j) - (*read_path_probs)(num_rows, j)) >= prob_precision) {
-
-                    is_identical = false;
-                    break;
-                }
-            }
-
-            if (abs((*noise_probs)(num_rows - 1, 0) - (*noise_probs)(num_rows, 0)) >= prob_precision) {
-
-                is_identical = false;
-            }
-
-            if (is_identical) {
-
-                (*read_counts)(0, num_rows - 1) += (*read_counts)(0, num_rows);
-
-            } else {
-
-                num_rows++;
-            }
-
-        } else {
-
-            num_rows++;
-        }
-    } 
-
-    if (num_rows < cluster_probs.size()) {
-
-        read_path_probs->conservativeResize(num_rows, read_path_probs->cols());
-        noise_probs->conservativeResize(num_rows, noise_probs->cols());
-        read_counts->conservativeResize(read_counts->rows(), num_rows);  
+        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProbability();
+        (*read_counts)(0, i) = cluster_probs.at(i).readCount();
     }
 }
 
@@ -152,7 +111,7 @@ void PathEstimator::rowSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_prob
     }    
 }
 
-void PathEstimator::collapseProbabilityMatrixReads(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) {
+void PathEstimator::readCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) {
 
     assert(read_path_probs->rows() > 0);
     assert(read_path_probs->rows() == read_counts->cols());
@@ -214,7 +173,7 @@ void PathEstimator::colSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_prob
     }    
 }
 
-void PathEstimator::collapseProbabilityMatrixPaths(Eigen::ColMatrixXd * read_path_probs) {
+void PathEstimator::pathCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs) {
 
     assert(read_path_probs->cols() > 0);    
     colSortProbabilityMatrix(read_path_probs);

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -32,8 +32,8 @@ class PathEstimator {
         void collapseProbabilityMatrixReads(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);
         void collapseProbabilityMatrixPaths(Eigen::ColMatrixXd * read_path_probs);
 
-        void calculatePathGroupPosteriors(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size);
-        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const uint32_t group_size, mt19937 * mt_rng);
+        void calculatePathGroupPosteriors(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size);
+        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng);
 
     private:
 

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -26,7 +26,7 @@ class PathEstimator {
        
         const double prob_precision;
  
-        void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids = vector<uint32_t>());
+        void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids);
         void addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, const Eigen::ColVectorXd & noise_probs);
 
         void collapseProbabilityMatrixReads(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -29,8 +29,8 @@ class PathEstimator {
         void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids);
         void addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, const Eigen::ColVectorXd & noise_probs);
 
-        void collapseProbabilityMatrixReads(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);
-        void collapseProbabilityMatrixPaths(Eigen::ColMatrixXd * read_path_probs);
+        void readCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);
+        void pathCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs);
 
         void calculatePathGroupPosteriors(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size);
         void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng);

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -26,7 +26,7 @@ class PathEstimator {
        
         const double prob_precision;
  
-        void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const bool add_noise);
+        void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids = vector<uint32_t>());
         void addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, const Eigen::ColVectorXd & noise_probs);
 
         void collapseProbabilityMatrixReads(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -17,7 +17,15 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
         noise_probs = read_path_probs.col(read_path_probs.cols() - 1);
         read_path_probs.conservativeResize(read_path_probs.rows(), read_path_probs.cols() - 1);
 
-        calculatePathGroupPosteriors(path_cluster_estimates, read_path_probs, noise_probs, read_counts, 1);
+        vector<uint32_t> path_counts;
+        path_counts.reserve(path_cluster_estimates->paths.size());
+
+        for (auto & path: path_cluster_estimates->paths) {
+
+            path_counts.emplace_back(path.count);
+        }
+
+        calculatePathGroupPosteriors(path_cluster_estimates, read_path_probs, noise_probs, read_counts, path_counts, 1);
 
         assert(path_cluster_estimates->posteriors.cols() == read_path_probs.cols());
         assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->paths.size());
@@ -47,13 +55,21 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
         noise_probs = read_path_probs.col(read_path_probs.cols() - 1);
         read_path_probs.conservativeResize(read_path_probs.rows(), read_path_probs.cols() - 1);
 
+        vector<uint32_t> path_counts;
+        path_counts.reserve(path_cluster_estimates->paths.size());
+
+        for (auto & path: path_cluster_estimates->paths) {
+
+            path_counts.emplace_back(path.count);
+        }
+
         if (use_exact) {
 
-            calculatePathGroupPosteriors(path_cluster_estimates, read_path_probs, noise_probs, read_counts, ploidy);
+            calculatePathGroupPosteriors(path_cluster_estimates, read_path_probs, noise_probs, read_counts, path_counts, ploidy);
         
         } else {
 
-            estimatePathGroupPosteriorsGibbs(path_cluster_estimates, read_path_probs, noise_probs, read_counts, ploidy, &mt_rng);
+            estimatePathGroupPosteriorsGibbs(path_cluster_estimates, read_path_probs, noise_probs, read_counts, path_counts, ploidy, &mt_rng);
         }
 
         assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->path_groups.size());

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -12,10 +12,7 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
         Eigen::ColVectorXd noise_probs;
         Eigen::RowVectorXui read_counts;
 
-        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, true);
-
-        noise_probs = read_path_probs.col(read_path_probs.cols() - 1);
-        read_path_probs.conservativeResize(read_path_probs.rows(), read_path_probs.cols() - 1);
+        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs);
 
         vector<uint32_t> path_counts;
         path_counts.reserve(path_cluster_estimates->paths.size());
@@ -50,10 +47,7 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
         Eigen::ColVectorXd noise_probs;
         Eigen::RowVectorXui read_counts;
 
-        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, true);
-
-        noise_probs = read_path_probs.col(read_path_probs.cols() - 1);
-        read_path_probs.conservativeResize(read_path_probs.rows(), read_path_probs.cols() - 1);
+        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs);
 
         vector<uint32_t> path_counts;
         path_counts.reserve(path_cluster_estimates->paths.size());

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -12,7 +12,10 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
         Eigen::ColVectorXd noise_probs;
         Eigen::RowVectorXui read_counts;
 
-        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs);
+        vector<uint32_t> path_ids(path_cluster_estimates->paths.size());
+        iota(path_ids.begin(), path_ids.end(), 0);
+
+        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_ids);
 
         vector<uint32_t> path_counts;
         path_counts.reserve(path_cluster_estimates->paths.size());
@@ -47,7 +50,10 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
         Eigen::ColVectorXd noise_probs;
         Eigen::RowVectorXui read_counts;
 
-        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs);
+        vector<uint32_t> path_ids(path_cluster_estimates->paths.size());
+        iota(path_ids.begin(), path_ids.end(), 0);
+
+        constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_ids);
 
         vector<uint32_t> path_counts;
         path_counts.reserve(path_cluster_estimates->paths.size());

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -76,6 +76,6 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
 
     } else {
 
-        path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), ploidy, true);
+        path_cluster_estimates->initEstimates(0, 0, true);
     }
 }

--- a/src/probability_matrix_writer.cpp
+++ b/src/probability_matrix_writer.cpp
@@ -44,17 +44,17 @@ void ProbabilityMatrixWriter::unlockWriter() {
 	writer_mutex.unlock();
 }
 
-void ProbabilityMatrixWriter::writeCollapsedProbabilities(const ReadPathProbabilities & probs) {
+void ProbabilityMatrixWriter::writeCollapsedProbabilities(const ReadPathProbabilities & read_path_probs) {
 
-    *writer_stream << probs.readCount() << " " << probs.noiseProbability();
+    *writer_stream << read_path_probs.readCount() << " " << read_path_probs.noiseProbability();
 
-    for (auto & prob: probs.collapsedProbabilities()) {
+    for (auto & collapsed_probs: read_path_probs.collapsedProbabilities()) {
 
-        *writer_stream << " " << prob.first << ":";
+        *writer_stream << " " << collapsed_probs.first << ":";
 
         bool is_first = true;
 
-        for (auto idx: prob.second) {
+        for (auto idx: collapsed_probs.second) {
 
             if (is_first) {
 
@@ -90,27 +90,11 @@ void ProbabilityMatrixWriter::writeReadPathProbabilityCluster(const vector<ReadP
 
         *writer_stream << setprecision(prob_precision_digits);
 
-        auto cluster_probs_it = cluster_probs.begin();
-        assert(cluster_probs_it != cluster_probs.end());
+        for (auto & probs: cluster_probs) {
 
-        ReadPathProbabilities cur_unique_probs = *cluster_probs_it;
-        ++cluster_probs_it;
-
-        while (cluster_probs_it != cluster_probs.end()) {
-
-            if (!cur_unique_probs.mergeIdenticalReadPathProbabilities(*cluster_probs_it)) {
-
-                assert(cur_unique_probs.probabilities().size() <= cluster_paths.size());
-                writeCollapsedProbabilities(cur_unique_probs);
-
-                cur_unique_probs = *cluster_probs_it;
-            }
-
-            ++cluster_probs_it;
+            assert(probs.probabilities().size() <= cluster_paths.size());
+            writeCollapsedProbabilities(probs);
         }
-
-        assert(cur_unique_probs.probabilities().size() <= cluster_paths.size());
-        writeCollapsedProbabilities(cur_unique_probs);
     }
 }
 

--- a/src/probability_matrix_writer.cpp
+++ b/src/probability_matrix_writer.cpp
@@ -44,29 +44,26 @@ void ProbabilityMatrixWriter::unlockWriter() {
 	writer_mutex.unlock();
 }
 
-void ProbabilityMatrixWriter::writeCollapsedProbabilities(const ReadPathProbabilities & probs, const bool write_zero) {
+void ProbabilityMatrixWriter::writeCollapsedProbabilities(const ReadPathProbabilities & probs) {
 
     *writer_stream << probs.readCount() << " " << probs.noiseProbability();
 
-    for (auto & prob: probs.collapsedProbabilities(prob_precision)) {
+    for (auto & prob: probs.collapsedProbabilities()) {
 
-        if (write_zero || prob.first > 0) {
+        *writer_stream << " " << prob.first << ":";
 
-            *writer_stream << " " << prob.first << ":";
+        bool is_first = true;
 
-            bool is_first = true;
+        for (auto idx: prob.second) {
 
-            for (auto idx: prob.second) {
+            if (is_first) {
 
-                if (is_first) {
+                *writer_stream << idx;
+                is_first = false;
 
-                    *writer_stream << idx;
-                    is_first = false;
+            } else {
 
-                } else {
-
-                    *writer_stream << "," << idx;
-                }
+                *writer_stream << "," << idx;
             }
         }
     }
@@ -101,10 +98,10 @@ void ProbabilityMatrixWriter::writeReadPathProbabilityCluster(const vector<ReadP
 
         while (cluster_probs_it != cluster_probs.end()) {
 
-            if (!cur_unique_probs.mergeIdenticalReadPathProbabilities(*cluster_probs_it, prob_precision)) {
+            if (!cur_unique_probs.mergeIdenticalReadPathProbabilities(*cluster_probs_it)) {
 
-                assert(cur_unique_probs.probabilities().size() == cluster_paths.size());
-                writeCollapsedProbabilities(cur_unique_probs, false);
+                assert(cur_unique_probs.probabilities().size() <= cluster_paths.size());
+                writeCollapsedProbabilities(cur_unique_probs);
 
                 cur_unique_probs = *cluster_probs_it;
             }
@@ -112,8 +109,8 @@ void ProbabilityMatrixWriter::writeReadPathProbabilityCluster(const vector<ReadP
             ++cluster_probs_it;
         }
 
-        assert(cur_unique_probs.probabilities().size() == cluster_paths.size());
-        writeCollapsedProbabilities(cur_unique_probs, false);
+        assert(cur_unique_probs.probabilities().size() <= cluster_paths.size());
+        writeCollapsedProbabilities(cur_unique_probs);
     }
 }
 

--- a/src/probability_matrix_writer.hpp
+++ b/src/probability_matrix_writer.hpp
@@ -37,7 +37,7 @@ class ProbabilityMatrixWriter {
 
     	mutex writer_mutex;
 
-        void writeCollapsedProbabilities(const vector<pair<double, vector<uint32_t> > > & collpased_probs, const bool write_zero);
+        void writeCollapsedProbabilities(const ReadPathProbabilities & probs, const bool write_zero);
 };
 
 

--- a/src/probability_matrix_writer.hpp
+++ b/src/probability_matrix_writer.hpp
@@ -37,7 +37,7 @@ class ProbabilityMatrixWriter {
 
     	mutex writer_mutex;
 
-        void writeCollapsedProbabilities(const ReadPathProbabilities & probs, const bool write_zero);
+        void writeCollapsedProbabilities(const ReadPathProbabilities & probs);
 };
 
 

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -67,19 +67,6 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             for (auto path_id: align_paths_ids.at(i)) {
 
                 auto clustered_path_index_it = clustered_path_index.find(path_id);
-
-                if (clustered_path_index_it == clustered_path_index.end()) {
-
-                    cerr << path_id << endl;
-                    cerr << align_paths_ids << endl;
-                
-                    for (auto & bla: clustered_path_index) {
-
-                        cerr << bla.first << " " << bla.second << endl;
-                    }
-                }
-
-
                 assert(clustered_path_index_it != clustered_path_index.end());
 
                 uint32_t path_idx = clustered_path_index_it->second;

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -7,8 +7,16 @@
 #include <limits>
 #include <sstream>
 
+ReadPathProbabilities::ReadPathProbabilities() {
 
-ReadPathProbabilities::ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in) : read_count(read_count_in), prob_precision(prob_precision_in), score_log_base(score_log_base_in), fragment_length_dist(fragment_length_dist_in) {
+    read_count = 0;
+    noise_prob = 1;
+
+    prob_precision = pow(10, -8);
+    score_log_base = 1;  
+}
+
+ReadPathProbabilities::ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in) : read_count(read_count_in), prob_precision(prob_precision_in), score_log_base(score_log_base_in) {
 
     noise_prob = 1;
 }
@@ -33,7 +41,7 @@ void ReadPathProbabilities::addReadCount(const uint32_t multiplicity_in) {
     read_count += multiplicity_in;
 }
 
-void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const unordered_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const bool is_single_end) {
+void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const unordered_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end) {
 
     assert(!align_paths.empty());
     assert(align_paths.size() == align_paths_ids.size());

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -8,10 +8,9 @@
 #include <sstream>
 
 
-ReadPathProbabilities::ReadPathProbabilities(const uint32_t read_count_in, const uint32_t num_paths, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in) : read_count(read_count_in), score_log_base(score_log_base_in), fragment_length_dist(fragment_length_dist_in) {
+ReadPathProbabilities::ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in) : read_count(read_count_in), prob_precision(prob_precision_in), score_log_base(score_log_base_in), fragment_length_dist(fragment_length_dist_in) {
 
     noise_prob = 1;
-    read_path_probs = vector<double>(num_paths, 0);
 }
 
 uint32_t ReadPathProbabilities::readCount() const {
@@ -24,7 +23,7 @@ double ReadPathProbabilities::noiseProbability() const {
     return noise_prob;
 }
 
-const vector<double> & ReadPathProbabilities::probabilities() const {
+const vector<pair<uint32_t, double> > & ReadPathProbabilities::probabilities() const {
 
     return read_path_probs;
 }
@@ -39,8 +38,7 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
     assert(!align_paths.empty());
     assert(align_paths.size() == align_paths_ids.size());
 
-    assert(clustered_path_index.size() == read_path_probs.size());
-    assert(cluster_paths.size() == read_path_probs.size());
+    assert(clustered_path_index.size() == cluster_paths.size());
 
     if (align_paths.front().mapq_comb > 0) {
 
@@ -60,7 +58,7 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             }
         }
         
-        vector<double> read_path_log_probs(read_path_probs.size(), numeric_limits<double>::lowest());
+        vector<double> read_path_log_probs(clustered_path_index.size(), numeric_limits<double>::lowest());
 
         for (size_t i = 0; i < align_paths.size(); ++i) {
 
@@ -91,26 +89,40 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             read_path_log_probs_sum = add_log(read_path_log_probs_sum, log_prob);
         }
 
-        assert(read_path_probs.size() == read_path_log_probs.size());
         assert(read_path_log_probs_sum > numeric_limits<double>::lowest());
+
+        for (size_t i = 0; i < read_path_log_probs.size(); ++i) {
+
+            read_path_log_probs.at(i) = exp(read_path_log_probs.at(i) - read_path_log_probs_sum);
+            read_path_log_probs.at(i) *= (1 - noise_prob);
+
+            if (read_path_log_probs.at(i) > prob_precision) {
+
+                read_path_probs.emplace_back(i, read_path_log_probs.at(i));
+            }
+        }
+    }
+
+    sort(read_path_probs.begin(), read_path_probs.end());
+}
+
+bool ReadPathProbabilities::mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2) {
+
+    if (probabilities().size() != probs_2.probabilities().size()) {
+
+        return false;
+    }
+
+    if (abs(noise_prob - probs_2.noiseProbability()) < prob_precision) {
 
         for (size_t i = 0; i < read_path_probs.size(); ++i) {
 
-            read_path_probs.at(i) = exp(read_path_log_probs.at(i) - read_path_log_probs_sum);
-            read_path_probs.at(i) *= (1 - noise_prob);
-        }
-    }
-}
+            if (read_path_probs.at(i).first != probs_2.probabilities().at(i).first) {
 
-bool ReadPathProbabilities::mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2, const double prob_precision) {
+                return false;
+            }  
 
-    assert(probabilities().size() == probs_2.probabilities().size());
-
-    if (abs(noiseProbability() - probs_2.noiseProbability()) < prob_precision) {
-
-        for (size_t i = 0; i < probabilities().size(); ++i) {
-
-            if (abs(probabilities().at(i) - probs_2.probabilities().at(i)) >= prob_precision) {
+            if (abs(read_path_probs.at(i).second - probs_2.probabilities().at(i).second) >= prob_precision) {
 
                 return false;
             }
@@ -123,19 +135,19 @@ bool ReadPathProbabilities::mergeIdenticalReadPathProbabilities(const ReadPathPr
     return false;
 }
 
-vector<pair<double, vector<uint32_t> > > ReadPathProbabilities::collapsedProbabilities(const double precision) const {
+vector<pair<double, vector<uint32_t> > > ReadPathProbabilities::collapsedProbabilities() const {
 
     vector<pair<double, vector<uint32_t> > > collapsed_probs;
 
-    for (size_t i = 0; i < read_path_probs.size(); ++i) {
+    for (auto & prob: read_path_probs) {
 
         auto collapsed_probs_it = collapsed_probs.begin();
 
         while (collapsed_probs_it != collapsed_probs.end()) {
 
-            if (abs(collapsed_probs_it->first - read_path_probs.at(i)) < precision) {
+            if (abs(collapsed_probs_it->first - prob.second) < prob_precision) {
 
-                collapsed_probs_it->second.emplace_back(i);
+                collapsed_probs_it->second.emplace_back(prob.first);
                 break;
             }
             
@@ -144,7 +156,7 @@ vector<pair<double, vector<uint32_t> > > ReadPathProbabilities::collapsedProbabi
 
         if (collapsed_probs_it == collapsed_probs.end()) {
 
-            collapsed_probs.emplace_back(read_path_probs.at(i), vector<uint32_t>(1, i));
+            collapsed_probs.emplace_back(prob.second, vector<uint32_t>(1, prob.first));
         }
     }
 
@@ -160,7 +172,12 @@ bool operator==(const ReadPathProbabilities & lhs, const ReadPathProbabilities &
 
             for (size_t i = 0; i < lhs.probabilities().size(); ++i) {
 
-                if (!doubleCompare(lhs.probabilities().at(i), rhs.probabilities().at(i))) {
+                if (lhs.probabilities().at(i).first != rhs.probabilities().at(i).first) {
+
+                    return false;
+                }  
+
+                if (!doubleCompare(lhs.probabilities().at(i).second, rhs.probabilities().at(i).second)) {
 
                     return false;
                 }
@@ -185,15 +202,23 @@ bool operator<(const ReadPathProbabilities & lhs, const ReadPathProbabilities & 
         return (lhs.noiseProbability() < rhs.noiseProbability());    
     } 
 
-    assert(lhs.probabilities().size() == rhs.probabilities().size());
+    if (lhs.probabilities().size() != rhs.probabilities().size()) {
+
+        return (lhs.probabilities().size() < rhs.probabilities().size());
+    }
 
     for (size_t i = 0; i < lhs.probabilities().size(); ++i) {
 
-        if (!doubleCompare(lhs.probabilities().at(i), rhs.probabilities().at(i))) {
+        if (lhs.probabilities().at(i).first != rhs.probabilities().at(i).first) {
 
-            return (lhs.probabilities().at(i) < rhs.probabilities().at(i));    
+            return (lhs.probabilities().at(i).first < rhs.probabilities().at(i).first);    
+        }  
+
+        if (!doubleCompare(lhs.probabilities().at(i).second, rhs.probabilities().at(i).second)) {
+
+            return (lhs.probabilities().at(i).second < rhs.probabilities().at(i).second);    
         }         
-    }   
+    }
 
     if (lhs.readCount() != rhs.readCount()) {
 
@@ -209,7 +234,7 @@ ostream & operator<<(ostream & os, const ReadPathProbabilities & read_path_probs
 
     for (auto & prob: read_path_probs.probabilities()) {
 
-        os << " " << prob;
+        os << " " << prob.first << "," << prob.second;
     }
 
     return os;

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -104,7 +104,7 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             read_path_log_probs.at(i) = exp(read_path_log_probs.at(i) - read_path_log_probs_sum);
             read_path_log_probs.at(i) *= (1 - noise_prob);
 
-            if (read_path_log_probs.at(i) > prob_precision) {
+            if (read_path_log_probs.at(i) >= prob_precision) {
 
                 read_path_probs.emplace_back(i, read_path_log_probs.at(i));
             }

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -67,6 +67,19 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
             for (auto path_id: align_paths_ids.at(i)) {
 
                 auto clustered_path_index_it = clustered_path_index.find(path_id);
+
+                if (clustered_path_index_it == clustered_path_index.end()) {
+
+                    cerr << path_id << endl;
+                    cerr << align_paths_ids << endl;
+                
+                    for (auto & bla: clustered_path_index) {
+
+                        cerr << bla.first << " " << bla.second << endl;
+                    }
+                }
+
+
                 assert(clustered_path_index_it != clustered_path_index.end());
 
                 uint32_t path_idx = clustered_path_index_it->second;

--- a/src/read_path_probabilities.hpp
+++ b/src/read_path_probabilities.hpp
@@ -17,15 +17,16 @@ using namespace std;
 class ReadPathProbabilities {
 
     public: 
-    	
-    	ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in);
+
+        ReadPathProbabilities();
+    	ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in);
 
         uint32_t readCount() const;
         double noiseProbability() const;
         const vector<pair<uint32_t, double> > & probabilities() const;
 
         void addReadCount(const uint32_t read_count_in);
-        void calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const unordered_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const bool is_single_end);
+        void calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const unordered_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end);
 
         bool mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2);
         vector<pair<double, vector<uint32_t> > > collapsedProbabilities() const;
@@ -38,7 +39,6 @@ class ReadPathProbabilities {
         
         double prob_precision;
         double score_log_base;
-        FragmentLengthDist fragment_length_dist;
 };
 
 bool operator==(const ReadPathProbabilities & lhs, const ReadPathProbabilities & rhs);

--- a/src/read_path_probabilities.hpp
+++ b/src/read_path_probabilities.hpp
@@ -18,24 +18,25 @@ class ReadPathProbabilities {
 
     public: 
     	
-    	ReadPathProbabilities(const uint32_t read_count_in, const uint32_t num_paths, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in);
+    	ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in, const FragmentLengthDist & fragment_length_dist_in);
 
         uint32_t readCount() const;
         double noiseProbability() const;
-        const vector<double> & probabilities() const;
+        const vector<pair<uint32_t, double> > & probabilities() const;
 
         void addReadCount(const uint32_t read_count_in);
         void calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const unordered_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const bool is_single_end);
 
-        bool mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2, const double prob_precision);
-        vector<pair<double, vector<uint32_t> > > collapsedProbabilities(const double precision) const;
+        bool mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2);
+        vector<pair<double, vector<uint32_t> > > collapsedProbabilities() const;
 
     private:
 
         uint32_t read_count;
         double noise_prob;
-        vector<double> read_path_probs;
+        vector<pair<uint32_t, double> > read_path_probs;
         
+        double prob_precision;
         double score_log_base;
         FragmentLengthDist fragment_length_dist;
 };

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -7,6 +7,54 @@
 #include "../utils.hpp"
 
 
+TEST_CASE("Test") {
+
+    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(8, true)));
+
+    gbwt::vector_type gbwt_thread_1(4);
+    gbwt::vector_type gbwt_thread_2(8);
+
+    gbwt_thread_1[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_1[1] = gbwt::Node::encode(2, false);
+    gbwt_thread_1[2] = gbwt::Node::encode(3, false);
+    gbwt_thread_1[3] = gbwt::Node::encode(4, false);
+
+    gbwt_thread_2[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_2[1] = gbwt::Node::encode(2, false);
+    gbwt_thread_2[2] = gbwt::Node::encode(2, false);
+    gbwt_thread_2[3] = gbwt::Node::encode(2, false);
+    gbwt_thread_2[4] = gbwt::Node::encode(3, false);
+    gbwt_thread_2[5] = gbwt::Node::encode(3, false);
+    gbwt_thread_2[6] = gbwt::Node::encode(4, false);
+
+    gbwt_builder.insert(gbwt_thread_1, true);    
+    gbwt_builder.insert(gbwt_thread_2, true);    
+
+    gbwt_builder.finish();
+
+    std::stringstream gbwt_stream;
+    gbwt_builder.index.serialize(gbwt_stream);
+
+    gbwt::GBWT gbwt_index;
+    gbwt_index.load(gbwt_stream);
+
+    auto bla = gbwt_index.find(gbwt::Node::encode(2, false));
+    auto bla2 = gbwt_index.find(gbwt::Node::encode(3, false));
+    auto bla3 = gbwt_index.find(gbwt::Node::encode(4, false));
+
+    cout << bla.size() << endl;
+    cout << bla2.size() << endl;
+    cout << bla3.size() << endl;
+
+    cout << gbwt_index.locate(bla) << endl;
+        cout << gbwt_index.locate(bla2) << endl;
+
+    cout << gbwt_index.locate(bla3) << endl;
+
+}
+
+
 TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     
     const string graph_str = R"(

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -7,54 +7,6 @@
 #include "../utils.hpp"
 
 
-TEST_CASE("Test") {
-
-    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(8, true)));
-
-    gbwt::vector_type gbwt_thread_1(4);
-    gbwt::vector_type gbwt_thread_2(8);
-
-    gbwt_thread_1[0] = gbwt::Node::encode(1, false);
-    gbwt_thread_1[1] = gbwt::Node::encode(2, false);
-    gbwt_thread_1[2] = gbwt::Node::encode(3, false);
-    gbwt_thread_1[3] = gbwt::Node::encode(4, false);
-
-    gbwt_thread_2[0] = gbwt::Node::encode(1, false);
-    gbwt_thread_2[1] = gbwt::Node::encode(2, false);
-    gbwt_thread_2[2] = gbwt::Node::encode(2, false);
-    gbwt_thread_2[3] = gbwt::Node::encode(2, false);
-    gbwt_thread_2[4] = gbwt::Node::encode(3, false);
-    gbwt_thread_2[5] = gbwt::Node::encode(3, false);
-    gbwt_thread_2[6] = gbwt::Node::encode(4, false);
-
-    gbwt_builder.insert(gbwt_thread_1, true);    
-    gbwt_builder.insert(gbwt_thread_2, true);    
-
-    gbwt_builder.finish();
-
-    std::stringstream gbwt_stream;
-    gbwt_builder.index.serialize(gbwt_stream);
-
-    gbwt::GBWT gbwt_index;
-    gbwt_index.load(gbwt_stream);
-
-    auto bla = gbwt_index.find(gbwt::Node::encode(2, false));
-    auto bla2 = gbwt_index.find(gbwt::Node::encode(3, false));
-    auto bla3 = gbwt_index.find(gbwt::Node::encode(4, false));
-
-    cout << bla.size() << endl;
-    cout << bla2.size() << endl;
-    cout << bla3.size() << endl;
-
-    cout << gbwt_index.locate(bla) << endl;
-        cout << gbwt_index.locate(bla2) << endl;
-
-    cout << gbwt_index.locate(bla3) << endl;
-
-}
-
-
 TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     
     const string graph_str = R"(

--- a/src/tests/alignment_path_test.cpp
+++ b/src/tests/alignment_path_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE("AlignmentPath can be created from AlignmentSearchPath") {
 	alignment_search_path.scores.push_back(50);
 	alignment_search_path.scores.push_back(60);
 
-	AlignmentPath alignment_path(alignment_search_path);
+	AlignmentPath alignment_path(alignment_search_path, false);
 	
 	REQUIRE(alignment_path.seq_length == 100);
 	REQUIRE(alignment_path.mapq_comb == 10);

--- a/src/tests/path_abundance_estimator_test.cpp
+++ b/src/tests/path_abundance_estimator_test.cpp
@@ -18,12 +18,12 @@ TEST_CASE("Weighted minimum path cover can be found") {
 	Eigen::RowVectorXd path_weights(1, 3);
 	path_weights << 1, 1, 1;
 
-	REQUIRE(path_abundance_estimator.weightedMinimumPathCover(read_path_cover, read_counts, path_weights) == vector<uint32_t>({1, 0}));
+	REQUIRE(path_abundance_estimator.weightedMinimumPathCover(read_path_cover, read_counts, path_weights) == vector<uint32_t>({0, 1}));
 
 	SECTION("Weights influence minimum path cover") {
 
 		path_weights(2) = 0.01;
-		REQUIRE(path_abundance_estimator.weightedMinimumPathCover(read_path_cover, read_counts, path_weights) == vector<uint32_t>({2, 1, 0}));
+		REQUIRE(path_abundance_estimator.weightedMinimumPathCover(read_path_cover, read_counts, path_weights) == vector<uint32_t>({0, 1, 2}));
 	}
 }
 

--- a/src/tests/path_clusters_test.cpp
+++ b/src/tests/path_clusters_test.cpp
@@ -8,175 +8,117 @@
 #include "../utils.hpp"
 
 
-TEST_CASE("Connected paths can be clustered") {
+TEST_CASE("GBWT paths can be clustered") {
 
-    REQUIRE(false);
+	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(7, true)));
 
-	// gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
- //    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(1, true)));
-
- //    gbwt_builder.index.addMetadata();
-
- //    for (uint32_t i = 0; i < 7; ++i) {
-
- //    	gbwt_builder.index.metadata.addPath(gbwt::PathName());
- //    }    
-
- //    gbwt_builder.finish();
-
- //    std::stringstream gbwt_stream;
- //    gbwt_builder.index.serialize(gbwt_stream);
-
- //    gbwt::GBWT gbwt_index;
- //    gbwt_index.load(gbwt_stream);
-
-	// vg::Graph graph;
-
- //    PathsIndex paths_index(gbwt_index, graph);
- //    REQUIRE(paths_index.index().metadata.paths() == 7);
-
-	// spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > connected_paths;
-	
-	// connected_paths[1].emplace(2);
-	// connected_paths[1].emplace(5);
-	// connected_paths[2].emplace(1);
-	// connected_paths[5].emplace(1);
-
-	// connected_paths[6].emplace(3);
-	// connected_paths[3].emplace(6);
-
-	// PathClusters path_clusters(1);
-	// path_clusters.findPathClusters(&connected_paths, paths_index);
-
- //    REQUIRE(path_clusters.path_to_cluster_index.size() == 7);
- //    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 1, 1, 2, 3, 1, 2}));
- //    REQUIRE(path_clusters.cluster_to_paths_index.size() == 4);
- //    REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0}));
- //    REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({1, 2, 5}));
- //    REQUIRE(path_clusters.cluster_to_paths_index.at(2) == vector<uint32_t>({3, 6}));
- //    REQUIRE(path_clusters.cluster_to_paths_index.at(3) == vector<uint32_t>({4}));
-}
-
-// TEST_CASE("GBWT paths can be clustered") {
-
-// 	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-//     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(7, true)));
-
-//     gbwt::vector_type gbwt_thread_1(3);
-//     gbwt::vector_type gbwt_thread_2(2);
-//     gbwt::vector_type gbwt_thread_3(1);
-//     gbwt::vector_type gbwt_thread_4(2);
+    gbwt::vector_type gbwt_thread_1(3);
+    gbwt::vector_type gbwt_thread_2(2);
+    gbwt::vector_type gbwt_thread_3(1);
+    gbwt::vector_type gbwt_thread_4(2);
    
-//     gbwt_thread_1[0] = gbwt::Node::encode(1, false);
-//     gbwt_thread_1[1] = gbwt::Node::encode(2, false);
-//     gbwt_thread_1[2] = gbwt::Node::encode(4, false);
+    gbwt_thread_1[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_1[1] = gbwt::Node::encode(2, false);
+    gbwt_thread_1[2] = gbwt::Node::encode(4, false);
 
-//     gbwt_thread_2[0] = gbwt::Node::encode(1, true);
-//     gbwt_thread_2[1] = gbwt::Node::encode(6, true);
+    gbwt_thread_2[0] = gbwt::Node::encode(1, true);
+    gbwt_thread_2[1] = gbwt::Node::encode(6, true);
 
-//     gbwt_thread_3[0] = gbwt::Node::encode(3, false);
+    gbwt_thread_3[0] = gbwt::Node::encode(3, false);
 
-//     gbwt_thread_4[0] = gbwt::Node::encode(6, false);
-//     gbwt_thread_4[1] = gbwt::Node::encode(7, false);
+    gbwt_thread_4[0] = gbwt::Node::encode(6, false);
+    gbwt_thread_4[1] = gbwt::Node::encode(7, false);
 
-//     gbwt_builder.insert(gbwt_thread_1, false);
-//     gbwt_builder.insert(gbwt_thread_2, false);
-//     gbwt_builder.insert(gbwt_thread_3, false);
-//     gbwt_builder.insert(gbwt_thread_4, false);
+    gbwt_builder.insert(gbwt_thread_1, false);
+    gbwt_builder.insert(gbwt_thread_2, false);
+    gbwt_builder.insert(gbwt_thread_3, false);
+    gbwt_builder.insert(gbwt_thread_4, false);
 
-//     gbwt_builder.index.addMetadata();
+    gbwt_builder.index.addMetadata();
 
-//     for (uint32_t i = 0; i < 4; ++i) {
+    for (uint32_t i = 0; i < 4; ++i) {
 
-//     	gbwt_builder.index.metadata.addPath(gbwt::PathName());
-//     }    
+    	gbwt_builder.index.metadata.addPath(gbwt::PathName());
+    }    
 
-//     gbwt_builder.finish();
+    gbwt_builder.finish();
 
-//     std::stringstream gbwt_stream;
-//     gbwt_builder.index.serialize(gbwt_stream);
+    std::stringstream gbwt_stream;
+    gbwt_builder.index.serialize(gbwt_stream);
 
-//     gbwt::GBWT gbwt_index;
-//     gbwt_index.load(gbwt_stream);
+    gbwt::GBWT gbwt_index;
+    gbwt_index.load(gbwt_stream);
 
-//     const string graph_str = R"(
-//     	{
-//     		"node": [
-//     			{"id": 1, "sequence": "A"},
-//     			{"id": 2, "sequence": "A"},
-//     			{"id": 3, "sequence": "A"},
-//     			{"id": 4, "sequence": "A"},
-//     			{"id": 5, "sequence": "A"},
-//     			{"id": 6, "sequence": "A"},
-//     			{"id": 7, "sequence": "A"}
-//     		],
-//     	}
-//     )";
+    const string graph_str = R"(
+    	{
+    		"node": [
+    			{"id": 1, "sequence": "A"},
+    			{"id": 2, "sequence": "A"},
+    			{"id": 3, "sequence": "A"},
+    			{"id": 4, "sequence": "A"},
+    			{"id": 5, "sequence": "A"},
+    			{"id": 6, "sequence": "A"},
+    			{"id": 7, "sequence": "A"}
+    		],
+    	}
+    )";
 
-// 	vg::Graph graph;
-// 	json2pb(graph, graph_str);
+	vg::Graph graph;
+	json2pb(graph, graph_str);
 
-//     PathsIndex paths_index(gbwt_index, graph);
-//     REQUIRE(paths_index.index().metadata.paths() == 4);
+    PathsIndex paths_index(gbwt_index, graph);
+    REQUIRE(paths_index.index().metadata.paths() == 4);
 
-// 	PathClusters path_clusters(1);
-// 	auto node_to_path_index = path_clusters.findPathNodeClusters(paths_index);
+	PathClusters path_clusters(paths_index, 1);
 
-//     REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
-//     REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 0, 1, 0}));
-//     REQUIRE(path_clusters.cluster_to_paths_index.size() == 2);
-//     REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0, 1, 3}));
-//     REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({2}));
+    REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
+    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 0, 1, 0}));
+    REQUIRE(path_clusters.cluster_to_paths_index.size() == 2);
+    REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0, 1, 3}));
+    REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({2}));
 
-//     REQUIRE(node_to_path_index.size() == 6);    
-//     REQUIRE(node_to_path_index.at(1) == 0);
-//     REQUIRE(node_to_path_index.at(2) == 0);
-//     REQUIRE(node_to_path_index.at(3) == 2);
-//     REQUIRE(node_to_path_index.at(4) == 0);
-//     REQUIRE(node_to_path_index.at(6) == 3);
-//     REQUIRE(node_to_path_index.at(7) == 3);
+    REQUIRE(path_clusters.node_to_path_index.size() == 6);    
+    REQUIRE(path_clusters.node_to_path_index.at(1) == 0);
+    REQUIRE(path_clusters.node_to_path_index.at(2) == 0);
+    REQUIRE(path_clusters.node_to_path_index.at(3) == 2);
+    REQUIRE(path_clusters.node_to_path_index.at(4) == 0);
+    REQUIRE(path_clusters.node_to_path_index.at(6) == 3);
+    REQUIRE(path_clusters.node_to_path_index.at(7) == 3);
 
-//     SECTION("Bidirectionality does not affect clustering") {
+    SECTION("Bidirectionality does not affect clustering") {
 
-//     	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-// 	    gbwt::GBWTBuilder gbwt_builder_bidi(gbwt::bit_length(gbwt::Node::encode(7, true)));
+    	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+	    gbwt::GBWTBuilder gbwt_builder_bidi(gbwt::bit_length(gbwt::Node::encode(7, true)));
 
-// 	    gbwt_builder_bidi.insert(gbwt_thread_1, true);
-// 	    gbwt_builder_bidi.insert(gbwt_thread_2, true);
-// 	    gbwt_builder_bidi.insert(gbwt_thread_3, true);
-// 	    gbwt_builder_bidi.insert(gbwt_thread_4, true);
+	    gbwt_builder_bidi.insert(gbwt_thread_1, true);
+	    gbwt_builder_bidi.insert(gbwt_thread_2, true);
+	    gbwt_builder_bidi.insert(gbwt_thread_3, true);
+	    gbwt_builder_bidi.insert(gbwt_thread_4, true);
 
-// 	    gbwt_builder_bidi.index.addMetadata();
+	    gbwt_builder_bidi.index.addMetadata();
 
-// 	    for (uint32_t i = 0; i < 4; ++i) {
+	    for (uint32_t i = 0; i < 4; ++i) {
 
-// 	    	gbwt_builder_bidi.index.metadata.addPath(gbwt::PathName());
-// 	    }    
+	    	gbwt_builder_bidi.index.metadata.addPath(gbwt::PathName());
+	    }    
 
-// 	    gbwt_builder_bidi.finish();
+	    gbwt_builder_bidi.finish();
 
-// 	    std::stringstream gbwt_stream_bidi;
-// 	    gbwt_builder_bidi.index.serialize(gbwt_stream_bidi);
+	    std::stringstream gbwt_stream_bidi;
+	    gbwt_builder_bidi.index.serialize(gbwt_stream_bidi);
 
-// 	    gbwt::GBWT gbwt_index_bidi;
-// 	    gbwt_index_bidi.load(gbwt_stream_bidi);
+	    gbwt::GBWT gbwt_index_bidi;
+	    gbwt_index_bidi.load(gbwt_stream_bidi);
 
-// 	    PathsIndex paths_index_bidi(gbwt_index_bidi, graph);
-// 	    REQUIRE(paths_index_bidi.index().metadata.paths() == 4);
+	    PathsIndex paths_index_bidi(gbwt_index_bidi, graph);
+	    REQUIRE(paths_index_bidi.index().metadata.paths() == 4);
 
-// 		PathClusters path_clusters_bidi(1);
-// 		auto node_to_path_index_bidi = path_clusters_bidi.findPathNodeClusters(paths_index_bidi);
+		PathClusters path_clusters_bidi(paths_index, 1);
 
-// 	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
-// 	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
-
-//     	REQUIRE(node_to_path_index_bidi.size() == 6);    
-//     	REQUIRE(node_to_path_index_bidi.at(1) == node_to_path_index.at(1));
-//     	REQUIRE(node_to_path_index_bidi.at(2) == node_to_path_index.at(2));
-//     	REQUIRE(node_to_path_index_bidi.at(3) == node_to_path_index.at(3));
-//     	REQUIRE(node_to_path_index_bidi.at(4) == node_to_path_index.at(4));
-//     	REQUIRE(node_to_path_index_bidi.at(6) == 1);
-//     	REQUIRE(node_to_path_index_bidi.at(7) == node_to_path_index.at(7));
-//     }
-// }
+	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
+	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
+	    REQUIRE(path_clusters_bidi.node_to_path_index == path_clusters.node_to_path_index);
+    }
+}
 

--- a/src/tests/path_clusters_test.cpp
+++ b/src/tests/path_clusters_test.cpp
@@ -10,171 +10,173 @@
 
 TEST_CASE("Connected paths can be clustered") {
 
-	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(1, true)));
+    REQUIRE(false);
 
-    gbwt_builder.index.addMetadata();
+	// gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+ //    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(1, true)));
 
-    for (uint32_t i = 0; i < 7; ++i) {
+ //    gbwt_builder.index.addMetadata();
 
-    	gbwt_builder.index.metadata.addPath(gbwt::PathName());
-    }    
+ //    for (uint32_t i = 0; i < 7; ++i) {
 
-    gbwt_builder.finish();
+ //    	gbwt_builder.index.metadata.addPath(gbwt::PathName());
+ //    }    
 
-    std::stringstream gbwt_stream;
-    gbwt_builder.index.serialize(gbwt_stream);
+ //    gbwt_builder.finish();
 
-    gbwt::GBWT gbwt_index;
-    gbwt_index.load(gbwt_stream);
+ //    std::stringstream gbwt_stream;
+ //    gbwt_builder.index.serialize(gbwt_stream);
 
-	vg::Graph graph;
+ //    gbwt::GBWT gbwt_index;
+ //    gbwt_index.load(gbwt_stream);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(paths_index.index().metadata.paths() == 7);
+	// vg::Graph graph;
 
-	spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > connected_paths;
+ //    PathsIndex paths_index(gbwt_index, graph);
+ //    REQUIRE(paths_index.index().metadata.paths() == 7);
+
+	// spp::sparse_hash_map<uint32_t, spp::sparse_hash_set<uint32_t> > connected_paths;
 	
-	connected_paths[1].emplace(2);
-	connected_paths[1].emplace(5);
-	connected_paths[2].emplace(1);
-	connected_paths[5].emplace(1);
+	// connected_paths[1].emplace(2);
+	// connected_paths[1].emplace(5);
+	// connected_paths[2].emplace(1);
+	// connected_paths[5].emplace(1);
 
-	connected_paths[6].emplace(3);
-	connected_paths[3].emplace(6);
+	// connected_paths[6].emplace(3);
+	// connected_paths[3].emplace(6);
 
-	PathClusters path_clusters(1);
-	path_clusters.findPathClusters(&connected_paths, paths_index);
+	// PathClusters path_clusters(1);
+	// path_clusters.findPathClusters(&connected_paths, paths_index);
 
-    REQUIRE(path_clusters.path_to_cluster_index.size() == 7);
-    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 1, 1, 2, 3, 1, 2}));
-    REQUIRE(path_clusters.cluster_to_paths_index.size() == 4);
-    REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0}));
-    REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({1, 2, 5}));
-    REQUIRE(path_clusters.cluster_to_paths_index.at(2) == vector<uint32_t>({3, 6}));
-    REQUIRE(path_clusters.cluster_to_paths_index.at(3) == vector<uint32_t>({4}));
+ //    REQUIRE(path_clusters.path_to_cluster_index.size() == 7);
+ //    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 1, 1, 2, 3, 1, 2}));
+ //    REQUIRE(path_clusters.cluster_to_paths_index.size() == 4);
+ //    REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0}));
+ //    REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({1, 2, 5}));
+ //    REQUIRE(path_clusters.cluster_to_paths_index.at(2) == vector<uint32_t>({3, 6}));
+ //    REQUIRE(path_clusters.cluster_to_paths_index.at(3) == vector<uint32_t>({4}));
 }
 
-TEST_CASE("GBWT paths can be clustered") {
+// TEST_CASE("GBWT paths can be clustered") {
 
-	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(7, true)));
+// 	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+//     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(7, true)));
 
-    gbwt::vector_type gbwt_thread_1(3);
-    gbwt::vector_type gbwt_thread_2(2);
-    gbwt::vector_type gbwt_thread_3(1);
-    gbwt::vector_type gbwt_thread_4(2);
+//     gbwt::vector_type gbwt_thread_1(3);
+//     gbwt::vector_type gbwt_thread_2(2);
+//     gbwt::vector_type gbwt_thread_3(1);
+//     gbwt::vector_type gbwt_thread_4(2);
    
-    gbwt_thread_1[0] = gbwt::Node::encode(1, false);
-    gbwt_thread_1[1] = gbwt::Node::encode(2, false);
-    gbwt_thread_1[2] = gbwt::Node::encode(4, false);
+//     gbwt_thread_1[0] = gbwt::Node::encode(1, false);
+//     gbwt_thread_1[1] = gbwt::Node::encode(2, false);
+//     gbwt_thread_1[2] = gbwt::Node::encode(4, false);
 
-    gbwt_thread_2[0] = gbwt::Node::encode(1, true);
-    gbwt_thread_2[1] = gbwt::Node::encode(6, true);
+//     gbwt_thread_2[0] = gbwt::Node::encode(1, true);
+//     gbwt_thread_2[1] = gbwt::Node::encode(6, true);
 
-    gbwt_thread_3[0] = gbwt::Node::encode(3, false);
+//     gbwt_thread_3[0] = gbwt::Node::encode(3, false);
 
-    gbwt_thread_4[0] = gbwt::Node::encode(6, false);
-    gbwt_thread_4[1] = gbwt::Node::encode(7, false);
+//     gbwt_thread_4[0] = gbwt::Node::encode(6, false);
+//     gbwt_thread_4[1] = gbwt::Node::encode(7, false);
 
-    gbwt_builder.insert(gbwt_thread_1, false);
-    gbwt_builder.insert(gbwt_thread_2, false);
-    gbwt_builder.insert(gbwt_thread_3, false);
-    gbwt_builder.insert(gbwt_thread_4, false);
+//     gbwt_builder.insert(gbwt_thread_1, false);
+//     gbwt_builder.insert(gbwt_thread_2, false);
+//     gbwt_builder.insert(gbwt_thread_3, false);
+//     gbwt_builder.insert(gbwt_thread_4, false);
 
-    gbwt_builder.index.addMetadata();
+//     gbwt_builder.index.addMetadata();
 
-    for (uint32_t i = 0; i < 4; ++i) {
+//     for (uint32_t i = 0; i < 4; ++i) {
 
-    	gbwt_builder.index.metadata.addPath(gbwt::PathName());
-    }    
+//     	gbwt_builder.index.metadata.addPath(gbwt::PathName());
+//     }    
 
-    gbwt_builder.finish();
+//     gbwt_builder.finish();
 
-    std::stringstream gbwt_stream;
-    gbwt_builder.index.serialize(gbwt_stream);
+//     std::stringstream gbwt_stream;
+//     gbwt_builder.index.serialize(gbwt_stream);
 
-    gbwt::GBWT gbwt_index;
-    gbwt_index.load(gbwt_stream);
+//     gbwt::GBWT gbwt_index;
+//     gbwt_index.load(gbwt_stream);
 
-    const string graph_str = R"(
-    	{
-    		"node": [
-    			{"id": 1, "sequence": "A"},
-    			{"id": 2, "sequence": "A"},
-    			{"id": 3, "sequence": "A"},
-    			{"id": 4, "sequence": "A"},
-    			{"id": 5, "sequence": "A"},
-    			{"id": 6, "sequence": "A"},
-    			{"id": 7, "sequence": "A"}
-    		],
-    	}
-    )";
+//     const string graph_str = R"(
+//     	{
+//     		"node": [
+//     			{"id": 1, "sequence": "A"},
+//     			{"id": 2, "sequence": "A"},
+//     			{"id": 3, "sequence": "A"},
+//     			{"id": 4, "sequence": "A"},
+//     			{"id": 5, "sequence": "A"},
+//     			{"id": 6, "sequence": "A"},
+//     			{"id": 7, "sequence": "A"}
+//     		],
+//     	}
+//     )";
 
-	vg::Graph graph;
-	json2pb(graph, graph_str);
+// 	vg::Graph graph;
+// 	json2pb(graph, graph_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(paths_index.index().metadata.paths() == 4);
+//     PathsIndex paths_index(gbwt_index, graph);
+//     REQUIRE(paths_index.index().metadata.paths() == 4);
 
-	PathClusters path_clusters(1);
-	auto node_to_path_index = path_clusters.findPathNodeClusters(paths_index);
+// 	PathClusters path_clusters(1);
+// 	auto node_to_path_index = path_clusters.findPathNodeClusters(paths_index);
 
-    REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
-    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 0, 1, 0}));
-    REQUIRE(path_clusters.cluster_to_paths_index.size() == 2);
-    REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0, 1, 3}));
-    REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({2}));
+//     REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
+//     REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 0, 1, 0}));
+//     REQUIRE(path_clusters.cluster_to_paths_index.size() == 2);
+//     REQUIRE(path_clusters.cluster_to_paths_index.at(0) == vector<uint32_t>({0, 1, 3}));
+//     REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({2}));
 
-    REQUIRE(node_to_path_index.size() == 6);    
-    REQUIRE(node_to_path_index.at(1) == 0);
-    REQUIRE(node_to_path_index.at(2) == 0);
-    REQUIRE(node_to_path_index.at(3) == 2);
-    REQUIRE(node_to_path_index.at(4) == 0);
-    REQUIRE(node_to_path_index.at(6) == 3);
-    REQUIRE(node_to_path_index.at(7) == 3);
+//     REQUIRE(node_to_path_index.size() == 6);    
+//     REQUIRE(node_to_path_index.at(1) == 0);
+//     REQUIRE(node_to_path_index.at(2) == 0);
+//     REQUIRE(node_to_path_index.at(3) == 2);
+//     REQUIRE(node_to_path_index.at(4) == 0);
+//     REQUIRE(node_to_path_index.at(6) == 3);
+//     REQUIRE(node_to_path_index.at(7) == 3);
 
-    SECTION("Bidirectionality does not affect clustering") {
+//     SECTION("Bidirectionality does not affect clustering") {
 
-    	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-	    gbwt::GBWTBuilder gbwt_builder_bidi(gbwt::bit_length(gbwt::Node::encode(7, true)));
+//     	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+// 	    gbwt::GBWTBuilder gbwt_builder_bidi(gbwt::bit_length(gbwt::Node::encode(7, true)));
 
-	    gbwt_builder_bidi.insert(gbwt_thread_1, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_2, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_3, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_4, true);
+// 	    gbwt_builder_bidi.insert(gbwt_thread_1, true);
+// 	    gbwt_builder_bidi.insert(gbwt_thread_2, true);
+// 	    gbwt_builder_bidi.insert(gbwt_thread_3, true);
+// 	    gbwt_builder_bidi.insert(gbwt_thread_4, true);
 
-	    gbwt_builder_bidi.index.addMetadata();
+// 	    gbwt_builder_bidi.index.addMetadata();
 
-	    for (uint32_t i = 0; i < 4; ++i) {
+// 	    for (uint32_t i = 0; i < 4; ++i) {
 
-	    	gbwt_builder_bidi.index.metadata.addPath(gbwt::PathName());
-	    }    
+// 	    	gbwt_builder_bidi.index.metadata.addPath(gbwt::PathName());
+// 	    }    
 
-	    gbwt_builder_bidi.finish();
+// 	    gbwt_builder_bidi.finish();
 
-	    std::stringstream gbwt_stream_bidi;
-	    gbwt_builder_bidi.index.serialize(gbwt_stream_bidi);
+// 	    std::stringstream gbwt_stream_bidi;
+// 	    gbwt_builder_bidi.index.serialize(gbwt_stream_bidi);
 
-	    gbwt::GBWT gbwt_index_bidi;
-	    gbwt_index_bidi.load(gbwt_stream_bidi);
+// 	    gbwt::GBWT gbwt_index_bidi;
+// 	    gbwt_index_bidi.load(gbwt_stream_bidi);
 
-	    PathsIndex paths_index_bidi(gbwt_index_bidi, graph);
-	    REQUIRE(paths_index_bidi.index().metadata.paths() == 4);
+// 	    PathsIndex paths_index_bidi(gbwt_index_bidi, graph);
+// 	    REQUIRE(paths_index_bidi.index().metadata.paths() == 4);
 
-		PathClusters path_clusters_bidi(1);
-		auto node_to_path_index_bidi = path_clusters_bidi.findPathNodeClusters(paths_index_bidi);
+// 		PathClusters path_clusters_bidi(1);
+// 		auto node_to_path_index_bidi = path_clusters_bidi.findPathNodeClusters(paths_index_bidi);
 
-	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
-	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
+// 	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
+// 	    REQUIRE(path_clusters_bidi.path_to_cluster_index == path_clusters.path_to_cluster_index);
 
-    	REQUIRE(node_to_path_index_bidi.size() == 6);    
-    	REQUIRE(node_to_path_index_bidi.at(1) == node_to_path_index.at(1));
-    	REQUIRE(node_to_path_index_bidi.at(2) == node_to_path_index.at(2));
-    	REQUIRE(node_to_path_index_bidi.at(3) == node_to_path_index.at(3));
-    	REQUIRE(node_to_path_index_bidi.at(4) == node_to_path_index.at(4));
-    	REQUIRE(node_to_path_index_bidi.at(6) == 1);
-    	REQUIRE(node_to_path_index_bidi.at(7) == node_to_path_index.at(7));
-    }
-}
+//     	REQUIRE(node_to_path_index_bidi.size() == 6);    
+//     	REQUIRE(node_to_path_index_bidi.at(1) == node_to_path_index.at(1));
+//     	REQUIRE(node_to_path_index_bidi.at(2) == node_to_path_index.at(2));
+//     	REQUIRE(node_to_path_index_bidi.at(3) == node_to_path_index.at(3));
+//     	REQUIRE(node_to_path_index_bidi.at(4) == node_to_path_index.at(4));
+//     	REQUIRE(node_to_path_index_bidi.at(6) == 1);
+//     	REQUIRE(node_to_path_index_bidi.at(7) == node_to_path_index.at(7));
+//     }
+// }
 

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -9,163 +9,173 @@
    
 const double score_log_base = gssw_dna_recover_log_base(1, 4, 0.5, double_precision);
 
-// TEST_CASE("Read path probabilities can be calculated from alignment paths") {
+TEST_CASE("Read path probabilities can be calculated from alignment paths") {
     
-// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
-// 	FragmentLengthDist fragment_length_dist(10, 2);
+	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
+	FragmentLengthDist fragment_length_dist(10, 2);
 
-// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
-// 	vector<PathInfo> paths(2);
-// 	paths.front().effective_length = 3;
-// 	paths.back().effective_length = 3;
+	vector<PathInfo> paths(2);
+	paths.front().effective_length = 3;
+	paths.back().effective_length = 3;
 
-// 	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
-// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+	ReadPathProbabilities read_path_probs(1, pow(10, -8), score_log_base);
+	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// 	REQUIRE(read_path_probs.readCount() == 1);
-// 	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-// 	REQUIRE(read_path_probs.probabilities().size() == 2);
-// 	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
-// 	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
+	REQUIRE(read_path_probs.readCount() == 1);
+	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
+	REQUIRE(read_path_probs.probabilities().size() == 2);
 
-//     SECTION("Improbable alignment path returns finite probabilities") {
+	REQUIRE(read_path_probs.probabilities().front().first == 0);
+	REQUIRE(doubleCompare(read_path_probs.probabilities().front().second, 0.45));
+	REQUIRE(read_path_probs.probabilities().back().first == 1);
+	REQUIRE(doubleCompare(read_path_probs.probabilities().back().second, 0.45));
 
-//     	alignment_paths.front().seq_length = 100000;
+    SECTION("Improbable alignment path returns finite probabilities") {
 
-// 		ReadPathProbabilities read_path_probs_2(1, 2, score_log_base, fragment_length_dist);
-// 		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+    	alignment_paths.front().seq_length = 100000;
 
-// 		REQUIRE(doubleCompare(read_path_probs_2.noiseProbability(), 0.1));
-// 		REQUIRE(read_path_probs_2.probabilities().size() == 2);
-// 		REQUIRE(read_path_probs.probabilities().front() - read_path_probs_2.probabilities().front() < pow(10, -8));
-// 		REQUIRE(read_path_probs.probabilities().back() - read_path_probs_2.probabilities().back() < pow(10, -8));
-// 	}
+		ReadPathProbabilities read_path_probs_2(1, pow(10, -8), score_log_base);
+		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-//     SECTION("Probabilities are calculated from multiple alignment paths") {
+		REQUIRE(doubleCompare(read_path_probs_2.noiseProbability(), 0.1));
+		REQUIRE(read_path_probs_2.probabilities().size() == 2);
 
-// 		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
-// 		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
+		REQUIRE(read_path_probs.probabilities().front().first == read_path_probs_2.probabilities().front().first);
+		REQUIRE(read_path_probs.probabilities().front().second - read_path_probs_2.probabilities().front().second < pow(10, -8));
+		REQUIRE(read_path_probs.probabilities().back().first == read_path_probs_2.probabilities().back().first);
+		REQUIRE(read_path_probs.probabilities().back().second - read_path_probs_2.probabilities().back().second < pow(10, -8));
+	}
+
+    SECTION("Probabilities are calculated from multiple alignment paths") {
+
+		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
+		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
 		
-// 		clustered_path_index.emplace(10, 2);
-// 		clustered_path_index.emplace(50, 3);
+		clustered_path_index.emplace(10, 2);
+		clustered_path_index.emplace(50, 3);
 
-// 		paths.emplace_back(PathInfo());
-// 		paths.back().effective_length = 3;
+		paths.emplace_back(PathInfo());
+		paths.back().effective_length = 3;
 
-// 		paths.emplace_back(PathInfo());
-// 		paths.back().effective_length = 3;
+		paths.emplace_back(PathInfo());
+		paths.back().effective_length = 3;
 
-// 		ReadPathProbabilities read_path_probs_3(1, 4, score_log_base, fragment_length_dist);
-// 		read_path_probs_3.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+		ReadPathProbabilities read_path_probs_3(1, pow(10, -8), score_log_base);
+		read_path_probs_3.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// 		REQUIRE(read_path_probs_3.readCount() == 1);
-// 		REQUIRE(doubleCompare(read_path_probs_3.noiseProbability(), 0.1));
-// 		REQUIRE(read_path_probs_3.probabilities().size() == 4);
-// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(0), 0.3334779864688257));
-// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(1), 0.3334779864688257));
-// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(2), 0));
-// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(3), 0.2330440270623483));
-// 	}
+		REQUIRE(read_path_probs_3.readCount() == 1);
+		REQUIRE(doubleCompare(read_path_probs_3.noiseProbability(), 0.1));
+		REQUIRE(read_path_probs_3.probabilities().size() == 3);
 
-//     SECTION("Effective path lengths affect probabilities") {
+		REQUIRE(read_path_probs_3.probabilities().at(0).first == 0);
+		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(0).second, 0.3334779864688257));
+		REQUIRE(read_path_probs_3.probabilities().at(1).first == 1);
+		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(1).second, 0.3334779864688257));
+		REQUIRE(read_path_probs_3.probabilities().at(2).first == 3);
+		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(2).second, 0.2330440270623483));
+	}
 
-// 		paths.back().effective_length = 2;
+    SECTION("Effective path lengths affect probabilities") {
 
-// 		ReadPathProbabilities read_path_probs_4(1, 2, score_log_base, fragment_length_dist);
-// 		read_path_probs_4.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+		paths.back().effective_length = 2;
 
-// 		REQUIRE(read_path_probs_4.readCount() == 1);
-// 		REQUIRE(doubleCompare(read_path_probs_4.noiseProbability(), 0.1));
-// 		REQUIRE(read_path_probs_4.probabilities().size() == 2);
-// 		REQUIRE(doubleCompare(read_path_probs_4.probabilities().front(), 0.3599999999999999));
-// 		REQUIRE(doubleCompare(read_path_probs_4.probabilities().back(), 0.5400000000000000));
-// 	}
-// }
+		ReadPathProbabilities read_path_probs_4(1, pow(10, -8), score_log_base);
+		read_path_probs_4.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// TEST_CASE("Identical read path probabilities can be merged") {
+		REQUIRE(read_path_probs_4.readCount() == 1);
+		REQUIRE(doubleCompare(read_path_probs_4.noiseProbability(), 0.1));
+		REQUIRE(read_path_probs_4.probabilities().size() == 2);
 
-// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
-// 	FragmentLengthDist fragment_length_dist(10, 2);
+		REQUIRE(read_path_probs.probabilities().front().first == 0);
+		REQUIRE(doubleCompare(read_path_probs_4.probabilities().front().second, 0.3599999999999999));
+		REQUIRE(read_path_probs.probabilities().back().first == 1);
+		REQUIRE(doubleCompare(read_path_probs_4.probabilities().back().second, 0.5400000000000000));
+	}
+}
 
-// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+TEST_CASE("Identical read path probabilities can be merged") {
 
-// 	vector<PathInfo> paths(2);
-// 	paths.front().effective_length = 3;
-// 	paths.back().effective_length = 3;
+	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
+	FragmentLengthDist fragment_length_dist(10, 2);
 
-// 	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
-// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
-// 	REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs, 0.001));
+	vector<PathInfo> paths(2);
+	paths.front().effective_length = 3;
+	paths.back().effective_length = 3;
 
-// 	REQUIRE(read_path_probs.readCount() == 2);
-// 	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-// 	REQUIRE(read_path_probs.probabilities().size() == 2);
-// 	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
-// 	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
+	ReadPathProbabilities read_path_probs(1, pow(10, -8), score_log_base);
+	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// 	SECTION("Probability precision affect merge") {
+	REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs));
 
-// 		vector<PathInfo> paths(2);
-// 		paths.front().effective_length = 2;
-// 		paths.back().effective_length = 3;
+	REQUIRE(read_path_probs.readCount() == 2);
+	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
+	REQUIRE(read_path_probs.probabilities().size() == 2);
 
-// 		ReadPathProbabilities read_path_probs_2(3, 2, score_log_base, fragment_length_dist);
-// 		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+	REQUIRE(read_path_probs.probabilities().front().first == 0);
+	REQUIRE(doubleCompare(read_path_probs.probabilities().front().second, 0.45));
+	REQUIRE(read_path_probs.probabilities().back().first == 1);
+	REQUIRE(doubleCompare(read_path_probs.probabilities().back().second, 0.45));
 
-// 		REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.1));
-// 		REQUIRE(read_path_probs.readCount() == 5);
+	SECTION("Probability precision affect merge") {
 
-// 		REQUIRE(!read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.01));
-// 		REQUIRE(read_path_probs.readCount() == 5);
-// 	}
-// }
+		vector<PathInfo> paths(2);
+		paths.front().effective_length = 2;
+		paths.back().effective_length = 3;
 
-// TEST_CASE("Read path probabilities can be collapsed") {
+		ReadPathProbabilities read_path_probs_2(3, 0.1, score_log_base);
+		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+
+		REQUIRE(read_path_probs_2.mergeIdenticalReadPathProbabilities(read_path_probs));
+		REQUIRE(read_path_probs_2.readCount() == 5);
+	}
+}
+
+TEST_CASE("Read path probabilities can be collapsed") {
 
 	
-// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
-// 	FragmentLengthDist fragment_length_dist(10, 2);
+	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
+	FragmentLengthDist fragment_length_dist(10, 2);
 
-// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-// 	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
 
-// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
-// 	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
+	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
 
-// 	vector<PathInfo> paths(4);
-// 	paths.at(0).effective_length = 3;
-// 	paths.at(1).effective_length = 3;
-// 	paths.at(2).effective_length = 3;
-// 	paths.at(3).effective_length = 3;
+	vector<PathInfo> paths(4);
+	paths.at(0).effective_length = 3;
+	paths.at(1).effective_length = 3;
+	paths.at(2).effective_length = 3;
+	paths.at(3).effective_length = 3;
 
-// 	ReadPathProbabilities read_path_probs(1, 4, score_log_base, fragment_length_dist);
-// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+	ReadPathProbabilities read_path_probs(1, 0.01, score_log_base);
+	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// 	auto collapsed_probs = read_path_probs.collapsedProbabilities(0.01);
-// 	REQUIRE(collapsed_probs.size() == 3);
+	auto collapsed_probs = read_path_probs.collapsedProbabilities();
+	REQUIRE(collapsed_probs.size() == 2);
 
-// 	REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
-// 	REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.233044027062348));
-// 	REQUIRE(doubleCompare(collapsed_probs.at(2).first, 0.3334779864688257));
+	REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0.233044027062348));
+	REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.3334779864688257));
 
-// 	REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
-// 	REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({3}));
-// 	REQUIRE(collapsed_probs.at(2).second == vector<uint32_t>({0, 1}));
+	REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({3}));
+	REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({0, 1}));
 
-// 	SECTION("Probability precision affect collapse") {
+	SECTION("Probability precision affect collapse") {
 
-// 		auto collapsed_probs = read_path_probs.collapsedProbabilities(0.2);
-// 		REQUIRE(collapsed_probs.size() == 2);
+		ReadPathProbabilities read_path_probs(1, 0.2, score_log_base);
+		read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
 
-// 		REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
-// 		REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.3334779864688257));
+		auto collapsed_probs = read_path_probs.collapsedProbabilities();
+		REQUIRE(collapsed_probs.size() == 1);
 
-// 		REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
-// 		REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({0, 1, 3}));
-// 	}
-// }
+		REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0.3334779864688257));
+		REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({0, 1, 3}));
+	}
+}
 

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, gbwt::SearchState()));
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
 	vector<PathInfo> paths(2);
@@ -45,7 +45,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 
     SECTION("Probabilities are calculated from multiple alignment paths") {
 
-		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, gbwt::SearchState()));
+		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
 		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
 		
 		clustered_path_index.emplace(10, 2);
@@ -89,7 +89,7 @@ TEST_CASE("Identical read path probabilities can be merged") {
 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, gbwt::SearchState()));
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
 	vector<PathInfo> paths(2);
@@ -130,8 +130,8 @@ TEST_CASE("Read path probabilities can be collapsed") {
 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, gbwt::SearchState()));
-	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, gbwt::SearchState()));
+	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
 
 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -9,163 +9,163 @@
    
 const double score_log_base = gssw_dna_recover_log_base(1, 4, 0.5, double_precision);
 
-TEST_CASE("Read path probabilities can be calculated from alignment paths") {
+// TEST_CASE("Read path probabilities can be calculated from alignment paths") {
     
-	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
-	FragmentLengthDist fragment_length_dist(10, 2);
+// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
+// 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
-	vector<PathInfo> paths(2);
-	paths.front().effective_length = 3;
-	paths.back().effective_length = 3;
+// 	vector<PathInfo> paths(2);
+// 	paths.front().effective_length = 3;
+// 	paths.back().effective_length = 3;
 
-	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
+// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-	REQUIRE(read_path_probs.readCount() == 1);
-	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-	REQUIRE(read_path_probs.probabilities().size() == 2);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
-	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
+// 	REQUIRE(read_path_probs.readCount() == 1);
+// 	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
+// 	REQUIRE(read_path_probs.probabilities().size() == 2);
+// 	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
+// 	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
 
-    SECTION("Improbable alignment path returns finite probabilities") {
+//     SECTION("Improbable alignment path returns finite probabilities") {
 
-    	alignment_paths.front().seq_length = 100000;
+//     	alignment_paths.front().seq_length = 100000;
 
-		ReadPathProbabilities read_path_probs_2(1, 2, score_log_base, fragment_length_dist);
-		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 		ReadPathProbabilities read_path_probs_2(1, 2, score_log_base, fragment_length_dist);
+// 		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-		REQUIRE(doubleCompare(read_path_probs_2.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_2.probabilities().size() == 2);
-		REQUIRE(read_path_probs.probabilities().front() - read_path_probs_2.probabilities().front() < pow(10, -8));
-		REQUIRE(read_path_probs.probabilities().back() - read_path_probs_2.probabilities().back() < pow(10, -8));
-	}
+// 		REQUIRE(doubleCompare(read_path_probs_2.noiseProbability(), 0.1));
+// 		REQUIRE(read_path_probs_2.probabilities().size() == 2);
+// 		REQUIRE(read_path_probs.probabilities().front() - read_path_probs_2.probabilities().front() < pow(10, -8));
+// 		REQUIRE(read_path_probs.probabilities().back() - read_path_probs_2.probabilities().back() < pow(10, -8));
+// 	}
 
-    SECTION("Probabilities are calculated from multiple alignment paths") {
+//     SECTION("Probabilities are calculated from multiple alignment paths") {
 
-		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
-		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
+// 		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
+// 		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
 		
-		clustered_path_index.emplace(10, 2);
-		clustered_path_index.emplace(50, 3);
+// 		clustered_path_index.emplace(10, 2);
+// 		clustered_path_index.emplace(50, 3);
 
-		paths.emplace_back(PathInfo());
-		paths.back().effective_length = 3;
+// 		paths.emplace_back(PathInfo());
+// 		paths.back().effective_length = 3;
 
-		paths.emplace_back(PathInfo());
-		paths.back().effective_length = 3;
+// 		paths.emplace_back(PathInfo());
+// 		paths.back().effective_length = 3;
 
-		ReadPathProbabilities read_path_probs_3(1, 4, score_log_base, fragment_length_dist);
-		read_path_probs_3.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 		ReadPathProbabilities read_path_probs_3(1, 4, score_log_base, fragment_length_dist);
+// 		read_path_probs_3.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-		REQUIRE(read_path_probs_3.readCount() == 1);
-		REQUIRE(doubleCompare(read_path_probs_3.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_3.probabilities().size() == 4);
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(0), 0.3334779864688257));
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(1), 0.3334779864688257));
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(2), 0));
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(3), 0.2330440270623483));
-	}
+// 		REQUIRE(read_path_probs_3.readCount() == 1);
+// 		REQUIRE(doubleCompare(read_path_probs_3.noiseProbability(), 0.1));
+// 		REQUIRE(read_path_probs_3.probabilities().size() == 4);
+// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(0), 0.3334779864688257));
+// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(1), 0.3334779864688257));
+// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(2), 0));
+// 		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(3), 0.2330440270623483));
+// 	}
 
-    SECTION("Effective path lengths affect probabilities") {
+//     SECTION("Effective path lengths affect probabilities") {
 
-		paths.back().effective_length = 2;
+// 		paths.back().effective_length = 2;
 
-		ReadPathProbabilities read_path_probs_4(1, 2, score_log_base, fragment_length_dist);
-		read_path_probs_4.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 		ReadPathProbabilities read_path_probs_4(1, 2, score_log_base, fragment_length_dist);
+// 		read_path_probs_4.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-		REQUIRE(read_path_probs_4.readCount() == 1);
-		REQUIRE(doubleCompare(read_path_probs_4.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_4.probabilities().size() == 2);
-		REQUIRE(doubleCompare(read_path_probs_4.probabilities().front(), 0.3599999999999999));
-		REQUIRE(doubleCompare(read_path_probs_4.probabilities().back(), 0.5400000000000000));
-	}
-}
+// 		REQUIRE(read_path_probs_4.readCount() == 1);
+// 		REQUIRE(doubleCompare(read_path_probs_4.noiseProbability(), 0.1));
+// 		REQUIRE(read_path_probs_4.probabilities().size() == 2);
+// 		REQUIRE(doubleCompare(read_path_probs_4.probabilities().front(), 0.3599999999999999));
+// 		REQUIRE(doubleCompare(read_path_probs_4.probabilities().back(), 0.5400000000000000));
+// 	}
+// }
 
-TEST_CASE("Identical read path probabilities can be merged") {
+// TEST_CASE("Identical read path probabilities can be merged") {
 
-	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
-	FragmentLengthDist fragment_length_dist(10, 2);
+// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
+// 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
 
-	vector<PathInfo> paths(2);
-	paths.front().effective_length = 3;
-	paths.back().effective_length = 3;
+// 	vector<PathInfo> paths(2);
+// 	paths.front().effective_length = 3;
+// 	paths.back().effective_length = 3;
 
-	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 	ReadPathProbabilities read_path_probs(1, 2, score_log_base, fragment_length_dist);
+// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-	REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs, 0.001));
+// 	REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs, 0.001));
 
-	REQUIRE(read_path_probs.readCount() == 2);
-	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-	REQUIRE(read_path_probs.probabilities().size() == 2);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
-	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
+// 	REQUIRE(read_path_probs.readCount() == 2);
+// 	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
+// 	REQUIRE(read_path_probs.probabilities().size() == 2);
+// 	REQUIRE(doubleCompare(read_path_probs.probabilities().front(), 0.45));
+// 	REQUIRE(doubleCompare(read_path_probs.probabilities().back(), 0.45));
 
-	SECTION("Probability precision affect merge") {
+// 	SECTION("Probability precision affect merge") {
 
-		vector<PathInfo> paths(2);
-		paths.front().effective_length = 2;
-		paths.back().effective_length = 3;
+// 		vector<PathInfo> paths(2);
+// 		paths.front().effective_length = 2;
+// 		paths.back().effective_length = 3;
 
-		ReadPathProbabilities read_path_probs_2(3, 2, score_log_base, fragment_length_dist);
-		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 		ReadPathProbabilities read_path_probs_2(3, 2, score_log_base, fragment_length_dist);
+// 		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-		REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.1));
-		REQUIRE(read_path_probs.readCount() == 5);
+// 		REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.1));
+// 		REQUIRE(read_path_probs.readCount() == 5);
 
-		REQUIRE(!read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.01));
-		REQUIRE(read_path_probs.readCount() == 5);
-	}
-}
+// 		REQUIRE(!read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs_2, 0.01));
+// 		REQUIRE(read_path_probs.readCount() == 5);
+// 	}
+// }
 
-TEST_CASE("Read path probabilities can be collapsed") {
+// TEST_CASE("Read path probabilities can be collapsed") {
 
 	
-	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
-	FragmentLengthDist fragment_length_dist(10, 2);
+// 	unordered_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
+// 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
+// 	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
+// 	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
 
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
-	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
+// 	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+// 	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
 
-	vector<PathInfo> paths(4);
-	paths.at(0).effective_length = 3;
-	paths.at(1).effective_length = 3;
-	paths.at(2).effective_length = 3;
-	paths.at(3).effective_length = 3;
+// 	vector<PathInfo> paths(4);
+// 	paths.at(0).effective_length = 3;
+// 	paths.at(1).effective_length = 3;
+// 	paths.at(2).effective_length = 3;
+// 	paths.at(3).effective_length = 3;
 
-	ReadPathProbabilities read_path_probs(1, 4, score_log_base, fragment_length_dist);
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
+// 	ReadPathProbabilities read_path_probs(1, 4, score_log_base, fragment_length_dist);
+// 	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, false);
 
-	auto collapsed_probs = read_path_probs.collapsedProbabilities(0.01);
-	REQUIRE(collapsed_probs.size() == 3);
+// 	auto collapsed_probs = read_path_probs.collapsedProbabilities(0.01);
+// 	REQUIRE(collapsed_probs.size() == 3);
 
-	REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
-	REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.233044027062348));
-	REQUIRE(doubleCompare(collapsed_probs.at(2).first, 0.3334779864688257));
+// 	REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
+// 	REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.233044027062348));
+// 	REQUIRE(doubleCompare(collapsed_probs.at(2).first, 0.3334779864688257));
 
-	REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
-	REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({3}));
-	REQUIRE(collapsed_probs.at(2).second == vector<uint32_t>({0, 1}));
+// 	REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
+// 	REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({3}));
+// 	REQUIRE(collapsed_probs.at(2).second == vector<uint32_t>({0, 1}));
 
-	SECTION("Probability precision affect collapse") {
+// 	SECTION("Probability precision affect collapse") {
 
-		auto collapsed_probs = read_path_probs.collapsedProbabilities(0.2);
-		REQUIRE(collapsed_probs.size() == 2);
+// 		auto collapsed_probs = read_path_probs.collapsedProbabilities(0.2);
+// 		REQUIRE(collapsed_probs.size() == 2);
 
-		REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
-		REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.3334779864688257));
+// 		REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0));
+// 		REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.3334779864688257));
 
-		REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
-		REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({0, 1, 3}));
-	}
-}
+// 		REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({2}));
+// 		REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({0, 1, 3}));
+// 	}
+// }
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -30,10 +30,6 @@ namespace Eigen {
     
     typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;
     typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXd;
-
-    typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMatrixXb;
-    typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMatrixXd;
-
 }
 
 //------------------------------------------------------------------------------

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -12,6 +12,7 @@
 #include <cmath>
 
 #include "Eigen/Dense"
+#include "Eigen/Sparse"
 #include "google/protobuf/util/json_util.h"
 #include "vg/io/basic_stream.hpp"
 #include "gbwt/gbwt.h"
@@ -30,6 +31,9 @@ namespace Eigen {
     
     typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;
     typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXd;
+
+    typedef Eigen::SparseMatrix<bool, Eigen::ColMajor> ColSparseMatrixXb;
+    typedef Eigen::SparseMatrix<double, Eigen::ColMajor> ColSparseMatrixXd;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains the following improvements:

* Added support for *mpmap* multi-mapped reads in the combined format (see `--agglomerate-alns` option in *mpmap*). Note that the graph needs to be an exon only splice graph in order for this to work properly. 
* Re-added read based clustering and optimized it. This was needed for the multi-mapping support.
* Reduced memory usage during inference by using a more sparse probability representation.
* Added use of haplotype frequencies to the inference model. 
* Improved mixing of Gibbs sampler by using multiple parallel chains.
* Fixed probability normalization bug when estimating the haplotypes for transcripts.
* Changed default mapq filter added in previous PR to 1. The mapq filtering actually decreased the accuracy a bit when looking at the results in more details. 
* Added probability precision threshold option. Used to collapse similar probability vectors and filter output.
* Only haplotype combinations with a posterior above the precision threshold are now written to the output. This is in order to scale better for high ploidies.
