### PR TITLE
Adds fragment length estimation 

### DIFF
--- a/src/alignment_path.hpp
+++ b/src/alignment_path.hpp
@@ -8,7 +8,6 @@
 #include "sparsepp/spp.h"
 #include "vg/io/basic_stream.hpp"
 
-#include "paths_index.hpp"
 #include "utils.hpp"
 
 using namespace std;

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -122,15 +122,7 @@ FragmentLengthDist::FragmentLengthDist(const spp::sparse_hash_map<vector<Alignme
 
         total_count += frag_length_count_buffer.at(i);
         sum_count += (i * frag_length_count_buffer.at(i));
-
-        if (frag_length_count_buffer.at(i) > 0) {
-
-            cerr << "(" << i << " " << frag_length_count_buffer.at(i) << ") ";
-        }
     }
-
-    cerr << endl;
-    cerr << total_count << endl;
 
     mean_ = sum_count / static_cast<double>(total_count);
 

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -93,7 +93,7 @@ FragmentLengthDist::FragmentLengthDist(const spp::sparse_hash_map<vector<Alignme
                             threaded_frag_length_count_buffer.resize(cur_frag_length + 1, 0);
                         }
 
-                        threaded_frag_length_count_buffer.at(cur_frag_length)++;
+                        threaded_frag_length_count_buffer.at(cur_frag_length) += align_paths.second;
                     }   
                 }
 
@@ -122,8 +122,14 @@ FragmentLengthDist::FragmentLengthDist(const spp::sparse_hash_map<vector<Alignme
 
         total_count += frag_length_count_buffer.at(i);
         sum_count += (i * frag_length_count_buffer.at(i));
+
+        if (frag_length_count_buffer.at(i) > 0) {
+
+            cerr << "(" << i << " " << frag_length_count_buffer.at(i) << ") ";
+        }
     }
 
+    cerr << endl;
     cerr << total_count << endl;
 
     mean_ = sum_count / static_cast<double>(total_count);

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -7,14 +7,21 @@
 #include "vg/io/protobuf_iterator.hpp"
 #include "utils.hpp"
 
-
+static const uint32_t frag_length_buffer_size = 1000;
 static const uint32_t max_length_sd_multiplicity = 10;
 
-FragmentLengthDist::FragmentLengthDist() : mean_(0), sd_(1) {}
-
-FragmentLengthDist::FragmentLengthDist(const double mean_in, const double sd_in): mean_(mean_in), sd_(sd_in) {
+FragmentLengthDist::FragmentLengthDist() : mean_(0), sd_(1) {
 
     assert(isValid());
+    setMaxLength();
+}
+
+FragmentLengthDist::FragmentLengthDist(const double mean_in, const double sd_in) : mean_(mean_in), sd_(sd_in) {
+
+    assert(isValid());
+
+    setMaxLength();
+    setLogProbBuffer(frag_length_buffer_size);
 }
 
 FragmentLengthDist::FragmentLengthDist(istream * alignments_istream, const bool is_multipath) {
@@ -43,6 +50,109 @@ FragmentLengthDist::FragmentLengthDist(istream * alignments_istream, const bool 
     }
 
     assert(isValid());
+
+    setMaxLength();
+    setLogProbBuffer(frag_length_buffer_size);
+}
+
+FragmentLengthDist::FragmentLengthDist(const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index, const uint32_t num_threads) {
+
+    vector<uint32_t> frag_length_count_buffer;
+
+    #pragma omp parallel num_threads(num_threads)
+    {
+        vector<uint32_t> threaded_frag_length_count_buffer;
+
+        #pragma omp for schedule(static, 1)
+        for (size_t i = 0; i < num_threads; ++i) {
+
+            uint32_t cur_align_paths_index_pos = 0;
+
+            for (auto & align_paths: align_paths_index) {
+
+                if (cur_align_paths_index_pos % num_threads == i) { 
+
+                    assert(!align_paths.first.empty());
+
+                    uint32_t cur_frag_length = align_paths.first.front().seq_length;
+                    bool cur_frag_length_is_constant = true;
+
+                    for (size_t j = 1; j < align_paths.first.size(); ++j) {
+
+                        if (align_paths.first.at(j).seq_length != cur_frag_length) {
+
+                            cur_frag_length_is_constant = false;
+                            break;
+                        }
+                    }
+
+                    if (cur_frag_length_is_constant) {
+
+                        if (threaded_frag_length_count_buffer.size() <= cur_frag_length) {
+                            
+                            threaded_frag_length_count_buffer.resize(cur_frag_length + 1, 0);
+                        }
+
+                        threaded_frag_length_count_buffer.at(cur_frag_length)++;
+                    }   
+                }
+
+                ++cur_align_paths_index_pos;
+            }
+        }
+
+        #pragma omp critical
+        {
+            if (frag_length_count_buffer.size() < threaded_frag_length_count_buffer.size()) {
+                
+                frag_length_count_buffer.resize(threaded_frag_length_count_buffer.size(), 0);
+            }
+
+            for (size_t i = 0; i < threaded_frag_length_count_buffer.size(); ++i) {
+
+                frag_length_count_buffer.at(i) += threaded_frag_length_count_buffer.at(i);
+            }
+        }
+    }
+
+    uint32_t total_count = 0;
+    uint64_t sum_count = 0; 
+
+    for (size_t i = 0; i < frag_length_count_buffer.size(); ++i) {
+
+        total_count += frag_length_count_buffer.at(i);
+        sum_count += (i * frag_length_count_buffer.at(i));
+    }
+
+    cerr << total_count << endl;
+
+    mean_ = sum_count / static_cast<double>(total_count);
+
+    if (total_count > 1) {
+
+        double sum_var = 0; 
+
+        for (size_t i = 0; i < frag_length_count_buffer.size(); ++i) {
+
+            sum_var += (pow(static_cast<double>(i) - mean_, 2) * frag_length_count_buffer.at(i));
+        }    
+
+        sd_ = sqrt(sum_var / static_cast<double>(total_count - 1));
+
+        if (total_count < 1000) {
+
+            cerr << "WARNING: Only " << total_count << " unambiguous read pairs available to re-estimate fragment length distribution parameters from alignment paths. Consider setting --frag-mean and --frag-sd instead." << endl;
+        }
+    
+        assert(isValid());
+
+        setMaxLength();
+        setLogProbBuffer(frag_length_count_buffer.size());
+
+    } else {
+
+        sd_ = 0;
+    }
 }
 
 bool FragmentLengthDist::parseAlignment(const vg::Alignment & alignment) {
@@ -109,13 +219,40 @@ bool FragmentLengthDist::isValid() const {
 
 uint32_t FragmentLengthDist::maxLength() const {
 
-    assert(isValid());
-    return ceil(mean_ + sd_ * max_length_sd_multiplicity);
+    assert(max_length_ > 0);
+    return max_length_;
 }
 
 double FragmentLengthDist::logProb(const uint32_t value) const {
 
-    assert(isValid());
-    return log_normal_pdf<double>(value, mean_, sd_);
+    if (value < log_prob_buffer.size()) {
+
+        return log_prob_buffer.at(value);
+    
+    } else {
+
+        return log_normal_pdf<double>(value, mean_, sd_);
+    }
 }
+
+void FragmentLengthDist::setMaxLength() {
+
+    assert(isValid());
+
+    max_length_ = ceil(mean_ + sd_ * max_length_sd_multiplicity);
+    assert(max_length_ > 0);
+}
+
+void FragmentLengthDist::setLogProbBuffer(const uint32_t size) {
+
+    assert(isValid());
+
+    log_prob_buffer = vector<double>(size);
+
+    for (size_t i = 0; i < size; ++i) {
+
+        log_prob_buffer.at(i) = log_normal_pdf<double>(i, mean_, sd_);
+    }
+}
+
 

--- a/src/fragment_length_dist.hpp
+++ b/src/fragment_length_dist.hpp
@@ -6,6 +6,9 @@
 #include <fstream>
 
 #include "vg/io/basic_stream.hpp"
+#include "sparsepp/spp.h"
+
+#include "alignment_path.hpp"
 
 using namespace std;
 
@@ -17,6 +20,7 @@ class FragmentLengthDist {
         FragmentLengthDist();
         FragmentLengthDist(const double mean_in, const double sd_in);
         FragmentLengthDist(istream * alignments_istream, const bool is_multipath);
+        FragmentLengthDist(const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index, const uint32_t num_threads);
 
         double mean() const;
         double sd() const;
@@ -29,9 +33,15 @@ class FragmentLengthDist {
         bool parseMultipathAlignment(const vg::MultipathAlignment & alignment);
 
     private:
-
+        
         double mean_;
         double sd_;
+        double max_length_;
+
+        vector<double> log_prob_buffer;
+
+        void setMaxLength();
+        void setLogProbBuffer(const uint32_t size); 
 };
 
 

--- a/src/fragment_length_dist.hpp
+++ b/src/fragment_length_dist.hpp
@@ -6,9 +6,6 @@
 #include <fstream>
 
 #include "vg/io/basic_stream.hpp"
-#include "sparsepp/spp.h"
-
-#include "alignment_path.hpp"
 
 using namespace std;
 

--- a/src/fragment_length_dist.hpp
+++ b/src/fragment_length_dist.hpp
@@ -20,7 +20,7 @@ class FragmentLengthDist {
         FragmentLengthDist();
         FragmentLengthDist(const double mean_in, const double sd_in);
         FragmentLengthDist(istream * alignments_istream, const bool is_multipath);
-        FragmentLengthDist(const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index, const uint32_t num_threads);
+        FragmentLengthDist(const vector<uint32_t> & frag_length_counts);
 
         double mean() const;
         double sd() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,9 +333,13 @@ int main(int argc, char* argv[]) {
 
     FragmentLengthDist pre_fragment_length_dist; 
 
-    if (!option_results.count("frag-mean") && !option_results.count("frag-sd")) {
+    if (is_long_reads) {
 
-        if (is_single_end && !is_long_reads) {
+        pre_fragment_length_dist = FragmentLengthDist(1, 1);
+
+    } else if (!option_results.count("frag-mean") && !option_results.count("frag-sd")) {
+
+        if (is_single_end) {
 
             cerr << "ERROR: Both --frag-mean and --frag-sd needs to be given as input when using single-end, short read alignments." << endl;
             return 1;            
@@ -440,7 +444,11 @@ int main(int argc, char* argv[]) {
     double time_frag = gbwt::readTimer();
     FragmentLengthDist fragment_length_dist; 
 
-    if (!option_results.count("frag-mean") && !option_results.count("frag-sd")) {
+    if (is_single_end && is_long_reads) {
+
+        fragment_length_dist = pre_fragment_length_dist;
+
+    } else {
 
         fragment_length_dist = FragmentLengthDist(align_paths_index, num_threads); 
 
@@ -454,11 +462,6 @@ int main(int argc, char* argv[]) {
 
         time_frag = gbwt::readTimer();
         cerr << "Estimated fragment length distribution parameters (" << time_frag - time_align << " seconds, " << gbwt::inGigabytes(gbwt::memoryUsage()) << " GB)" << endl;
-
-    } else {
-
-        fragment_length_dist = pre_fragment_length_dist;
-
     }
 
     PathClusters path_clusters(paths_index, num_threads);
@@ -514,8 +517,6 @@ int main(int argc, char* argv[]) {
 
         assert(false);
     }
-
-    cerr << haplotype_transcript_info.size() << endl;
 
     vector<vector<vector<ReadPathProbabilities> > > threaded_read_path_cluster_probs_buffer(num_threads);
     vector<vector<PathClusterEstimates> > threaded_path_cluster_estimates(num_threads);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,12 +61,6 @@ void addAlignmentPathsToBuffer(const vector<AlignmentPath> & align_paths, vector
 
         if (!align_paths_buffer->back().empty()) {
 
-            if (align_paths_buffer->back().size() == 1) {
-
-                align_paths_buffer->back().front().seq_length = mean_fragment_length;
-                align_paths_buffer->back().front().score_sum = 1;
-            } 
-
             sort(align_paths_buffer->back().begin(), align_paths_buffer->back().end());
 
         } else {
@@ -520,6 +514,8 @@ int main(int argc, char* argv[]) {
 
         assert(false);
     }
+
+    cerr << haplotype_transcript_info.size() << endl;
 
     vector<vector<vector<ReadPathProbabilities> > > threaded_read_path_cluster_probs_buffer(num_threads);
     vector<vector<PathClusterEstimates> > threaded_path_cluster_estimates(num_threads);

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -277,7 +277,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
             group_read_path_probs.col(group_read_path_probs.cols() - 1) = group_noise_probs;
 
             readCollapseProbabilityMatrix(&group_read_path_probs, &group_read_counts);
-            group_read_counts = Eigen::RowVectorXui::Constant(group_read_counts.cols(), 1);
 
             group_noise_probs = group_read_path_probs.col(group_read_path_probs.cols() - 1);
             group_read_path_probs.conservativeResize(group_read_path_probs.rows(), group_read_path_probs.cols() - 1);

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -277,6 +277,7 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
             group_read_path_probs.col(group_read_path_probs.cols() - 1) = group_noise_probs;
 
             readCollapseProbabilityMatrix(&group_read_path_probs, &group_read_counts);
+            group_read_counts = Eigen::RowVectorXui::Constant(group_read_counts.cols(), 1);
 
             group_noise_probs = group_read_path_probs.col(group_read_path_probs.cols() - 1);
             group_read_path_probs.conservativeResize(group_read_path_probs.rows(), group_read_path_probs.cols() - 1);

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -17,7 +17,7 @@ ReadPathProbabilities::ReadPathProbabilities() {
 }
 
 ReadPathProbabilities::ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in, const double score_log_base_in) : read_count(read_count_in), prob_precision(prob_precision_in), score_log_base(score_log_base_in) {
-
+    
     noise_prob = 1;
 }
 


### PR DESCRIPTION
This PR contains the following improvements:
* The fragment length distribution parameters are now re-estimated by rpvg. This generally results in better TPM estimates since vg mpmap has a tendency to slightly underestimate the mean. The fragment length distribution parameters found in the alignments are still used to calculate the maximum search distance used when looking for read alignment paths in the GBWT.
* The fragment length probabilities are also now cached which should result in a slight increase in speed.