### PR TITLE
Bug fixes and smaller improvements

### DIFF
--- a/src/alignment_path.hpp
+++ b/src/alignment_path.hpp
@@ -19,11 +19,11 @@ class AlignmentPath {
 
     public: 
         
-        AlignmentPath(const uint32_t seq_length_in, const uint32_t mapq_comb_in, const uint32_t score_sum_in, const bool is_multimap_in, const gbwt::SearchState & search_state_in);
+        AlignmentPath(const uint32_t seq_length_in, const uint32_t min_mapq_in, const uint32_t score_sum_in, const bool is_multimap_in, const gbwt::SearchState & search_state_in);
         AlignmentPath(const AlignmentSearchPath & align_path_in, const bool is_multimap_in);
 
         uint32_t seq_length;
-        uint32_t mapq_comb;
+        uint32_t min_mapq;
         uint32_t score_sum;
 
         bool is_multimap;
@@ -51,7 +51,7 @@ namespace std {
             for (auto & align_path: align_paths) {
 
                 spp::hash_combine(seed, align_path.seq_length);
-                spp::hash_combine(seed, align_path.mapq_comb);
+                spp::hash_combine(seed, align_path.min_mapq);
                 spp::hash_combine(seed, align_path.score_sum);
                 spp::hash_combine(seed, align_path.is_multimap);
                 spp::hash_combine(seed, align_path.search_state.node);
@@ -80,13 +80,10 @@ class AlignmentSearchPath {
 
         uint32_t seq_length;
 
-        vector<uint32_t> mapqs;
-        vector<uint32_t> scores;
+        uint32_t min_mapq;
+        vector<int32_t> scores;
 
-        double mapqProb() const;
-        uint32_t mapqComb() const;
         uint32_t scoreSum() const;
-
         bool complete() const;
 };
 

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -253,22 +253,6 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentPaths(vector<AlignmentSe
     }
 }
 
-// Debug start
-
-char quality_short_to_char(short i) {
-    return static_cast<char>(i + 33);
-}
-
-string string_quality_short_to_char(const string& quality) {
-    string buffer; buffer.resize(quality.size());
-    for (int i = 0; i < quality.size(); ++i) {
-        buffer[i] = quality_short_to_char(quality[i]);
-    }
-    return buffer;
-}
-
-// Debug end
-
 template<class AlignmentType>
 vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPaths(const AlignmentType & alignment_1, const AlignmentType & alignment_2) const {
 
@@ -304,77 +288,6 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPat
     }
 
     auto paired_align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(paired_align_search_paths, isAlignmentDisconnected(alignment_1) || isAlignmentDisconnected(alignment_2));
-
-    // Debug start
-
-    // string debug_paths = "";
-    // uint32_t debug_idx = 0;
-
-    // string debug_paths2 = "";
-    // uint32_t debug_idx2 = 0;
-
-    // for (size_t i = 0; i < paired_align_search_paths.size(); ++i) {
-
-    //     if (paired_align_search_paths.at(i).complete()) {
-
-    //         for (auto & path_id: paths_index.locatePathIds(paired_align_search_paths.at(i).search_state)) {
-
-    //             auto path_name = paths_index.pathName(path_id);
-
-    //             if (path_name == "ENST00000646664.1_74" || 
-    //                 path_name == "ENST00000227378.7_51" || 
-    //                 path_name == "ENST00000514057.1_60" || 
-    //                 path_name == "ENST00000394667.7_2" || 
-    //                 path_name == "ENST00000253788.11_9" ||
-    //                 path_name == "ENST00000511473.5_9" ||
-    //                 path_name == "ENST00000287038.7_4" ||
-    //                 path_name == "ENST00000370321.8_25" ||
-    //                 path_name == "ENST00000412585.6_300" ||
-    //                 path_name == "ENST00000412585.6_2760" ||
-    //                 path_name == "ENST00000648437.1_2"
-    //                 ) {
-
-    //                 debug_paths = path_name; 
-    //                 debug_idx = i;         
-                
-    //             } else if (path_name == "ENST00000646664.1_7" || 
-    //                         path_name == "ENST00000227378.7" || 
-    //                         path_name == "ENST00000514057.1" || 
-    //                         path_name == "ENST00000514057.1_538" || 
-    //                         path_name == "ENST00000394667.7" || 
-    //                         path_name == "ENST00000253788.11_21" || 
-    //                         path_name == "ENST00000511473.5" ||
-    //                         path_name == "ENST00000287038.7" ||
-    //                         path_name == "ENST00000370321.8" ||
-    //                         path_name == "ENST00000412585.6_496" ||
-    //                         path_name == "ENST00000412585.6_2604" ||
-    //                         path_name == "ENST00000648437.1_17") {
-
-    //                 debug_paths2 = path_name; 
-    //                 debug_idx2 = i;         
-    //             }                
-    //         }
-    //     }
-    // }
-
-    // if (!debug_paths.empty() && debug_paths2.empty()) {
-
-    //     #pragma omp critical
-    //     {
-    //         cerr << "\n\n" << endl;
-    //         cerr << debug_paths << endl;
-    //         cerr << debug_idx << endl;
-    //         cerr << paired_align_search_paths << endl;
-    //         cerr << endl;
-    //         cerr << pb2json(alignment_1) << endl;
-    //         cerr << string_quality_short_to_char(alignment_1.quality()) << endl;
-    //         cerr << endl;
-    //         cerr << pb2json(alignment_2) << endl;
-    //         cerr << string_quality_short_to_char(alignment_2.quality()) << endl;
-    //     }
-    // }   
-
-    // Debug end
 
 #ifdef debug
 

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -8,7 +8,7 @@
 #include "utils.hpp"
 
 static const uint32_t frag_length_buffer_size = 1000;
-static const uint32_t max_length_sd_multiplicity = 10;
+static const uint32_t max_length_sd_multiplicity = 5;
 
 FragmentLengthDist::FragmentLengthDist() : mean_(0), sd_(1) {
 
@@ -65,6 +65,8 @@ FragmentLengthDist::FragmentLengthDist(const vector<uint32_t> & frag_length_coun
         total_count += frag_length_counts.at(i);
         sum_count += (i * frag_length_counts.at(i));
     }
+
+    cerr << total_count << endl;
 
     mean_ = sum_count / static_cast<double>(total_count);
 

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -300,44 +300,6 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
                 estimatePathGroupPosteriorsGibbs(&group_path_cluster_estimates, group_read_path_probs, group_noise_probs, group_read_counts, group_path_counts, ploidy, &mt_rng);
             }
 
-            // Debug start
-
-            if (path_cluster_estimates->paths.at(group.front()).origin == "ENST00000646664.1" || 
-                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000227378.7" || 
-                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000514057.1" || 
-                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000394667.7" || 
-                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000253788.11") {
-
-                stringstream debug_stream;
-                debug_stream << "\n######\n" << endl;
-
-                for (size_t i = 0; i < group.size(); ++i) {
-
-                    debug_stream << path_cluster_estimates->paths.at(group.at(i)).name << "\t" << path_cluster_estimates->paths.at(group.at(i)).count << endl;
-                }
-
-                debug_stream << endl;
-
-                assert(group_path_cluster_estimates.path_groups.size() == group_path_cluster_estimates.posteriors.cols());
-
-                for (size_t i = 0; i < group_path_cluster_estimates.path_groups.size(); ++i) {
-
-                    if (group_path_cluster_estimates.posteriors(i) > 0) {
-
-                        for (auto & id: group_path_cluster_estimates.path_groups.at(i)) {
-
-                            debug_stream << path_cluster_estimates->paths.at(group.at(id)).name << ",";
-                        }                    
-
-                        debug_stream << "\t" << group_path_cluster_estimates.posteriors(i) << endl;
-                    }
-                }
-
-                cerr << debug_stream.str() << endl;
-            }
-
-            // Debug end
-
             samplePloidyPathIndices(&ploidy_path_indices_samples, group_path_cluster_estimates, group);
         }
 

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -300,6 +300,44 @@ void NestedPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_
                 estimatePathGroupPosteriorsGibbs(&group_path_cluster_estimates, group_read_path_probs, group_noise_probs, group_read_counts, group_path_counts, ploidy, &mt_rng);
             }
 
+            // Debug start
+
+            if (path_cluster_estimates->paths.at(group.front()).origin == "ENST00000646664.1" || 
+                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000227378.7" || 
+                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000514057.1" || 
+                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000394667.7" || 
+                path_cluster_estimates->paths.at(group.front()).origin == "ENST00000253788.11") {
+
+                stringstream debug_stream;
+                debug_stream << "\n######\n" << endl;
+
+                for (size_t i = 0; i < group.size(); ++i) {
+
+                    debug_stream << path_cluster_estimates->paths.at(group.at(i)).name << "\t" << path_cluster_estimates->paths.at(group.at(i)).count << endl;
+                }
+
+                debug_stream << endl;
+
+                assert(group_path_cluster_estimates.path_groups.size() == group_path_cluster_estimates.posteriors.cols());
+
+                for (size_t i = 0; i < group_path_cluster_estimates.path_groups.size(); ++i) {
+
+                    if (group_path_cluster_estimates.posteriors(i) > 0) {
+
+                        for (auto & id: group_path_cluster_estimates.path_groups.at(i)) {
+
+                            debug_stream << path_cluster_estimates->paths.at(group.at(id)).name << ",";
+                        }                    
+
+                        debug_stream << "\t" << group_path_cluster_estimates.posteriors(i) << endl;
+                    }
+                }
+
+                cerr << debug_stream.str() << endl;
+            }
+
+            // Debug end
+
             samplePloidyPathIndices(&ploidy_path_indices_samples, group_path_cluster_estimates, group);
         }
 

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -39,6 +39,8 @@ class PathEstimator {
 
         void rowSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts);
         void colSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs);
+
+        vector<double> calcPathFrequences(const vector<uint32_t> & path_counts);
 };
 
 namespace std {

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -48,9 +48,9 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
 
     assert(clustered_path_index.size() == cluster_paths.size());
 
-    if (align_paths.front().mapq_comb > 0) {
+    if (align_paths.front().min_mapq > 0) {
 
-        noise_prob = phred_to_prob(align_paths.front().mapq_comb);
+        noise_prob = phred_to_prob(align_paths.front().min_mapq);
         assert(noise_prob < 1);
 
         vector<double> align_paths_log_probs;
@@ -85,7 +85,7 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
                 } else {
 
                     // account for really rare cases when a mpmap alignment can have multiple alignments on the same path
-                    read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), align_paths_log_probs.at(i) - log(cluster_paths.at(path_idx).effective_length));
+                    read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), align_paths_log_probs.at(i) - log(align_paths_ids.size()) - log(cluster_paths.at(path_idx).effective_length));
                 }
             }
         }

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -101,12 +101,12 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     SECTION("Single-end read alignment finds alignment path(s)") {    
 
         REQUIRE(alignment_paths.front().seq_length == 8);
-        REQUIRE(alignment_paths.front().mapq_comb == 10);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
         REQUIRE(alignment_paths.front().score_sum == 1);
         REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));
 
         REQUIRE(alignment_paths.back().seq_length == alignment_paths.front().seq_length);
-        REQUIRE(alignment_paths.back().mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.back().score_sum == alignment_paths.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));
     }
@@ -174,7 +174,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
         REQUIRE(alignment_paths_bd.size() == 1);
 
         REQUIRE(alignment_paths_bd.front().seq_length == alignment_paths.front().seq_length);
-        REQUIRE(alignment_paths_bd.front().mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths_bd.front().min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths_bd.front().score_sum == alignment_paths.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_bd.front().search_state) == vector<gbwt::size_type>({0}));
     }
@@ -310,17 +310,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
     SECTION("Paired-end read alignment finds alignment path(s)") {
 
         REQUIRE(alignment_paths.front().seq_length == 19);
-        REQUIRE(alignment_paths.front().mapq_comb == 10);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
         REQUIRE(alignment_paths.front().score_sum == 3);
         REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));
 
         REQUIRE(alignment_paths.at(1).seq_length == 17);
-        REQUIRE(alignment_paths.at(1).mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({2}));
 
         REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).seq_length);
-        REQUIRE(alignment_paths.back().mapq_comb == alignment_paths.at(1).mapq_comb);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
         REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));
     }
@@ -429,12 +429,12 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         REQUIRE(alignment_paths_ov_1.size() == 2);
 
         REQUIRE(alignment_paths_ov_1.front().seq_length == 8);
-        REQUIRE(alignment_paths_ov_1.front().mapq_comb == 7);
+        REQUIRE(alignment_paths_ov_1.front().min_mapq == 10);
         REQUIRE(alignment_paths_ov_1.front().score_sum == 2);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().search_state) == vector<gbwt::size_type>({0, 2}));
 
         REQUIRE(alignment_paths_ov_1.back().seq_length == alignment_paths_ov_1.front().seq_length);
-        REQUIRE(alignment_paths_ov_1.back().mapq_comb == alignment_paths_ov_1.front().mapq_comb);
+        REQUIRE(alignment_paths_ov_1.back().min_mapq == alignment_paths_ov_1.front().min_mapq);
         REQUIRE(alignment_paths_ov_1.back().score_sum == alignment_paths_ov_1.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.back().search_state) == vector<gbwt::size_type>({1}));
 
@@ -444,12 +444,12 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         REQUIRE(alignment_paths_ov_2.size() == 2);
 
         REQUIRE(alignment_paths_ov_2.front().seq_length == 4);
-        REQUIRE(alignment_paths_ov_2.front().mapq_comb == 17);
+        REQUIRE(alignment_paths_ov_2.front().min_mapq == 20);
         REQUIRE(alignment_paths_ov_2.front().score_sum == 4);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().search_state) == vector<gbwt::size_type>({1}));
 
         REQUIRE(alignment_paths_ov_2.back().seq_length == alignment_paths_ov_2.front().seq_length);
-        REQUIRE(alignment_paths_ov_2.back().mapq_comb == alignment_paths_ov_2.front().mapq_comb);
+        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.front().min_mapq);
         REQUIRE(alignment_paths_ov_2.back().score_sum == alignment_paths_ov_2.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.back().search_state) == vector<gbwt::size_type>({0, 2, 3}));
     }
@@ -625,17 +625,17 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
     SECTION("Paired-end read alignment finds circular alignment path(s)") {
 
         REQUIRE(alignment_paths.front().seq_length == 10);
-        REQUIRE(alignment_paths.front().mapq_comb == 10);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
         REQUIRE(alignment_paths.front().score_sum == 3);
         REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));        
 
         REQUIRE(alignment_paths.at(1).seq_length == 18);
-        REQUIRE(alignment_paths.at(1).mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({1}));                
 
         REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).seq_length);
-        REQUIRE(alignment_paths.back().mapq_comb == alignment_paths.at(1).mapq_comb);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
         REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({2}));   
     }
@@ -785,7 +785,7 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         REQUIRE(alignment_paths_bd.front() == alignment_paths.front());
 
         REQUIRE(alignment_paths_bd.back().seq_length == alignment_paths.back().seq_length);
-        REQUIRE(alignment_paths_bd.back().mapq_comb == alignment_paths.back().mapq_comb);
+        REQUIRE(alignment_paths_bd.back().min_mapq == alignment_paths.back().min_mapq);
         REQUIRE(alignment_paths_bd.back().score_sum == alignment_paths.back().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_bd.back().search_state) == vector<gbwt::size_type>({1}));                
     }
@@ -944,12 +944,12 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
     SECTION("Single-end multipath read alignment finds alignment path(s)") {
 
         REQUIRE(alignment_paths.front().seq_length == 8);
-        REQUIRE(alignment_paths.front().mapq_comb == 10);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
         REQUIRE(alignment_paths.front().score_sum == 14);
         REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));                
   
         REQUIRE(alignment_paths.back().seq_length == alignment_paths.front().seq_length);
-        REQUIRE(alignment_paths.back().mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.back().score_sum == 12);
         REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));                
     }
@@ -1203,17 +1203,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
     SECTION("Paired-end multipath read alignment finds alignment path(s)") {
 
         REQUIRE(alignment_paths.front().seq_length == 10);
-        REQUIRE(alignment_paths.front().mapq_comb == 10);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
         REQUIRE(alignment_paths.front().score_sum == 20);
         REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({1}));                
 
         REQUIRE(alignment_paths.at(1).seq_length == 7);
-        REQUIRE(alignment_paths.at(1).mapq_comb == alignment_paths.front().mapq_comb);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({0}));                
 
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).mapq_comb);
-        REQUIRE(alignment_paths.back().mapq_comb == alignment_paths.at(1).mapq_comb);
+        REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
         REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({2}));                
     }
@@ -1287,17 +1287,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_ov_1.size() == 3);
 
         REQUIRE(alignment_paths_ov_1.front().seq_length == 3);
-        REQUIRE(alignment_paths_ov_1.front().mapq_comb == 7);
+        REQUIRE(alignment_paths_ov_1.front().min_mapq == 10);
         REQUIRE(alignment_paths_ov_1.front().score_sum == 20);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().search_state) == vector<gbwt::size_type>({0}));                
 
         REQUIRE(alignment_paths_ov_1.at(1).seq_length == alignment_paths_ov_1.front().seq_length);
-        REQUIRE(alignment_paths_ov_1.at(1).mapq_comb == alignment_paths_ov_1.front().mapq_comb);
+        REQUIRE(alignment_paths_ov_1.at(1).min_mapq == alignment_paths_ov_1.front().min_mapq);
         REQUIRE(alignment_paths_ov_1.at(1).score_sum == 16);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.at(1).search_state) == vector<gbwt::size_type>({1}));                
 
         REQUIRE(alignment_paths_ov_1.back().seq_length == alignment_paths_ov_1.at(1).seq_length);
-        REQUIRE(alignment_paths_ov_1.back().mapq_comb == alignment_paths_ov_1.at(1).mapq_comb);
+        REQUIRE(alignment_paths_ov_1.back().min_mapq == alignment_paths_ov_1.at(1).min_mapq);
         REQUIRE(alignment_paths_ov_1.back().score_sum == alignment_paths_ov_1.at(1).score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.back().search_state) == vector<gbwt::size_type>({2}));
 
@@ -1307,17 +1307,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_ov_2.size() == 3);
 
         REQUIRE(alignment_paths_ov_2.front().seq_length == 3);
-        REQUIRE(alignment_paths_ov_2.front().mapq_comb == 17);
+        REQUIRE(alignment_paths_ov_2.front().min_mapq == 20);
         REQUIRE(alignment_paths_ov_2.front().score_sum == 24);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().search_state) == vector<gbwt::size_type>({2}));                
 
         REQUIRE(alignment_paths_ov_2.at(1).seq_length == alignment_paths_ov_2.front().seq_length);
-        REQUIRE(alignment_paths_ov_2.at(1).mapq_comb == alignment_paths_ov_2.front().mapq_comb);
+        REQUIRE(alignment_paths_ov_2.at(1).min_mapq == alignment_paths_ov_2.front().min_mapq);
         REQUIRE(alignment_paths_ov_2.at(1).score_sum == 20);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.at(1).search_state) == vector<gbwt::size_type>({0}));                
 
         REQUIRE(alignment_paths_ov_2.back().seq_length == alignment_paths_ov_2.at(1).seq_length);
-        REQUIRE(alignment_paths_ov_2.back().mapq_comb == alignment_paths_ov_2.at(1).mapq_comb);
+        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.at(1).min_mapq);
         REQUIRE(alignment_paths_ov_2.back().score_sum == alignment_paths_ov_2.front().score_sum);
         REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.back().search_state) == vector<gbwt::size_type>({1}));                
     }

--- a/src/tests/alignment_path_test.cpp
+++ b/src/tests/alignment_path_test.cpp
@@ -7,31 +7,6 @@
 #include "../utils.hpp"
 
 
-TEST_CASE("Multiple mapping qualities can be combined into single probability") {
-    
-	AlignmentSearchPath alignment_search_path;
-
-	alignment_search_path.mapqs.push_back(10);
-	REQUIRE(doubleCompare(alignment_search_path.mapqProb(), 0.1));
-
-	alignment_search_path.mapqs.push_back(20);
-	REQUIRE(doubleCompare(alignment_search_path.mapqProb(), 0.109));
-
-    SECTION("Mapping quality of zero returns one") {
-
-		alignment_search_path.mapqs.push_back(0);
-		REQUIRE(doubleCompare(alignment_search_path.mapqProb(), 1));
-	}
-
-    SECTION("Mapping quality order not relevant") {
-
-		auto alignment_path_mapq_rev = alignment_search_path;
-
-    	swap(alignment_path_mapq_rev.mapqs.front(), alignment_path_mapq_rev.mapqs.back());
-		REQUIRE(doubleCompare(alignment_path_mapq_rev.mapqProb(), alignment_search_path.mapqProb()));
-	}
-}
-
 TEST_CASE("Empty AlignmentSearchPath is not complete") {
     
 	AlignmentSearchPath alignment_search_path;
@@ -43,17 +18,15 @@ TEST_CASE("AlignmentPath can be created from AlignmentSearchPath") {
 	AlignmentSearchPath alignment_search_path;
 
 	alignment_search_path.seq_length = 100;
-
-	alignment_search_path.mapqs.push_back(10);
-	alignment_search_path.mapqs.push_back(20);
-
+	alignment_search_path.min_mapq = 10;
+	
 	alignment_search_path.scores.push_back(50);
 	alignment_search_path.scores.push_back(60);
 
 	AlignmentPath alignment_path(alignment_search_path, false);
 	
 	REQUIRE(alignment_path.seq_length == 100);
-	REQUIRE(alignment_path.mapq_comb == 10);
+	REQUIRE(alignment_path.min_mapq == 10);
 	REQUIRE(alignment_path.score_sum == 110);
 	REQUIRE(alignment_path.search_state.empty());
 }

--- a/src/tests/fragment_length_dist_test.cpp
+++ b/src/tests/fragment_length_dist_test.cpp
@@ -10,7 +10,7 @@ TEST_CASE("FragmentLengthDist is valid normal distribution") {
 	FragmentLengthDist fragment_length_dist(10, 2);
 
     REQUIRE(fragment_length_dist.isValid());	
-    REQUIRE(fragment_length_dist.maxLength() == 30);
+    REQUIRE(fragment_length_dist.maxLength() == 20);
 
     REQUIRE(doubleCompare(fragment_length_dist.logProb(9), -1.737085713764618));
     REQUIRE(doubleCompare(fragment_length_dist.logProb(15), -4.737085713764618));

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -153,6 +153,8 @@ inline vg::Alignment lazy_reverse_complement_alignment(const vg::Alignment& aln,
     // TODO: should we/can we do this in place?
     
     vg::Alignment aln_rc;
+
+    aln_rc.set_sequence(aln.sequence());
     aln_rc.set_score(aln.score());
     aln_rc.set_mapping_quality(aln.mapping_quality());
 
@@ -162,11 +164,13 @@ inline vg::Alignment lazy_reverse_complement_alignment(const vg::Alignment& aln,
 }
 
 
-// Reverse complements multipath alignment. Note that edit sequences, paths and edit sequences 
+// Reverse complements multipath alignment. Note that sequences, paths and edit sequences 
 // are not reverse complemented. Original name in vg repo: rev_comp_multipath_alignment().
 inline vg::MultipathAlignment lazy_reverse_complement_alignment(const vg::MultipathAlignment& multipath_aln, const function<int64_t(int64_t)>& node_length) {
     
     vg::MultipathAlignment multipath_aln_rc;
+
+    multipath_aln_rc.set_sequence(multipath_aln.sequence());
     multipath_aln_rc.set_mapping_quality(multipath_aln.mapping_quality());
 
     vector< vector<size_t> > reverse_edge_lists(multipath_aln.subpath_size());


### PR DESCRIPTION
Bug fixes:

* Fixed bug where reads were not paired if there was an indel at the first position of the second read. This fix results in an overall increased computation time. 
* Fixed bug where a negative total alignment score would be considered really good.
* Fixed bug where the transcript path multiplicity was not accounted for in the probability normalization. 

Changes to existing options:

* Made the multipath alignment (gamp) format from mpmap the default input. Changed the `-u` option to instead specify that  the input is single-path format (gam). 

General improvements:

* Decreased the maximum search distance when pairing read. This results in an overall decreased computation time without sacrificing accuracy. 
* Changed it so that the minimum mapping quality is now used for read-pairs instead of incorrectly assuming independence between the two.
* Added a mapping quality and multi-mapping read filter to the fragment length distribution estimation.
* Added a scoring difference filter that removes low probable alignment paths with a score that is 24 below the best scoring alignment path. This can be changed using the `-w, --filt-score-diff` option.
