### PR TITLE
Read count bug fix in Gibbs sample output 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -640,7 +640,7 @@ int main(int argc, char* argv[]) {
         unordered_map<uint32_t, uint32_t> clustered_path_index;
 
         auto * path_cluster_estimates = &(threaded_path_cluster_estimates.at(omp_get_thread_num()));
-        path_cluster_estimates->emplace_back(i, PathClusterEstimates());
+        path_cluster_estimates->emplace_back(i + 1, PathClusterEstimates());
 
         path_cluster_estimates->back().second.paths.reserve(path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size());
         
@@ -722,8 +722,8 @@ int main(int argc, char* argv[]) {
 
         if (gibbs_samples_writer) {
 
-            gibbs_samples_writer->addSamples(path_cluster_estimates->back().second);
-            path_cluster_estimates->back().second.gibbs_abundance_samples.clear();
+            gibbs_samples_writer->addSamples(path_cluster_estimates->back());
+            path_cluster_estimates->back().second.gibbs_read_count_samples.clear();
         }
 
         // if (path_clusters.cluster_to_paths_index.at(align_paths_cluster_idx).size() > 1000 || align_paths_clusters.at(align_paths_cluster_idx).size() > 1000) {

--- a/src/path_abundance_estimator.hpp
+++ b/src/path_abundance_estimator.hpp
@@ -34,7 +34,7 @@ class PathAbundanceEstimator : public PathEstimator {
         const uint32_t gibbs_thin_its;
 
         void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::RowVectorXui & read_counts) const;
-        void gibbsAbundanceSampler(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const;
+        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const;
         void removeNoiseAndRenormalizeAbundances(PathClusterEstimates * path_cluster_estimates) const;    
         void updateEstimates(PathClusterEstimates * path_cluster_estimates, const PathClusterEstimates & new_path_cluster_estimates, const vector<uint32_t> & path_indices, const uint32_t sample_count) const;
 };

--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -29,7 +29,7 @@ struct PathInfo {
     }
 };
 
-struct AbundanceSamples {
+struct CountSamples {
     
     vector<uint32_t> path_ids;
     vector<vector<double> > samples;
@@ -43,7 +43,7 @@ struct PathClusterEstimates {
     Eigen::RowVectorXd abundances;
 
     double total_read_count;
-    vector<AbundanceSamples> gibbs_abundance_samples;
+    vector<CountSamples> gibbs_read_count_samples;
 
     vector<vector<uint32_t> > path_groups;
 

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -7,7 +7,7 @@ ThreadedOutputWriter::ThreadedOutputWriter(const string & filename, const string
 
     writer_stream = bgzf_open(filename.c_str(), compression_mode.c_str());
 
-    output_queue = new ProducerConsumerQueue<stringstream *>(num_threads * 3);
+    output_queue = new ProducerConsumerQueue<stringstream *>(num_threads * 5);
     writing_thread = thread(&ThreadedOutputWriter::write, this);
 }
 
@@ -102,7 +102,7 @@ void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & 
 GibbsSamplesWriter::GibbsSamplesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t num_gibbs_samples_in) : ThreadedOutputWriter(filename_prefix + "_gibbs.txt.gz", "wg", num_threads), num_gibbs_samples(num_gibbs_samples_in) {
 
     auto out_sstream = new stringstream;
-    *out_sstream << "Name\tHaplotypeSampleId";
+    *out_sstream << "Name\tClusterID\tHaplotypeSampleId";
 
     for (size_t i = 1; i <= num_gibbs_samples; ++i) {
 
@@ -113,34 +113,35 @@ GibbsSamplesWriter::GibbsSamplesWriter(const string filename_prefix, const uint3
     output_queue->push(out_sstream);
 }
 
-void GibbsSamplesWriter::addSamples(const PathClusterEstimates & path_cluster_estimate) {
+void GibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEstimates> & path_cluster_estimate) {
 
-    if (!path_cluster_estimate.gibbs_abundance_samples.empty()) {
+    if (!path_cluster_estimate.second.gibbs_read_count_samples.empty()) {
 
         uint32_t cur_hap_sample_id = 0;
         auto out_sstream = new stringstream;
 
-        for (auto & abundance_samples: path_cluster_estimate.gibbs_abundance_samples) {
+        for (auto & read_count_samples: path_cluster_estimate.second.gibbs_read_count_samples) {
 
-            assert(!abundance_samples.path_ids.empty());
-            assert(abundance_samples.path_ids.size() == abundance_samples.samples.size());
+            assert(!read_count_samples.path_ids.empty());
+            assert(read_count_samples.path_ids.size() == read_count_samples.samples.size());
 
-            assert(abundance_samples.samples.front().size() % num_gibbs_samples == 0);
+            assert(read_count_samples.samples.front().size() % num_gibbs_samples == 0);
 
-            for (size_t i = 0; i < abundance_samples.samples.front().size(); i += num_gibbs_samples) {
+            for (size_t i = 0; i < read_count_samples.samples.front().size(); i += num_gibbs_samples) {
 
                 ++cur_hap_sample_id;
 
-                for (size_t j = 0; j < abundance_samples.path_ids.size(); ++j) {
+                for (size_t j = 0; j < read_count_samples.path_ids.size(); ++j) {
 
-                    assert(abundance_samples.samples.front().size() == abundance_samples.samples.at(j).size());
+                    assert(read_count_samples.samples.front().size() == read_count_samples.samples.at(j).size());
 
-                    *out_sstream << path_cluster_estimate.paths.at(abundance_samples.path_ids.at(j)).name;
+                    *out_sstream << path_cluster_estimate.second.paths.at(read_count_samples.path_ids.at(j)).name;
+                    *out_sstream << "\t" << path_cluster_estimate.first;
                     *out_sstream << "\t" << cur_hap_sample_id;
 
                     for (size_t k = 0; k < num_gibbs_samples; ++k) {
 
-                        *out_sstream << "\t" << abundance_samples.samples.at(j).at(i + k);
+                        *out_sstream << "\t" << read_count_samples.samples.at(j).at(i + k);
                     }
 
                     *out_sstream << endl;

--- a/src/threaded_output_writer.hpp
+++ b/src/threaded_output_writer.hpp
@@ -61,7 +61,7 @@ class GibbsSamplesWriter : public ThreadedOutputWriter {
         GibbsSamplesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t num_gibbs_samples_in);
         ~GibbsSamplesWriter() {};
 
-        void addSamples(const PathClusterEstimates & path_cluster_estimate);
+        void addSamples(const pair<uint32_t, PathClusterEstimates> & path_cluster_estimate);
 
     private:
 


### PR DESCRIPTION
Changes to existing options and outputs:

* Changed cluster ids to start at one instead of zero. 
* Added cluster id column (*ClusterID*) to Gibbs samples output (*\<output-prefix\>_gibbs.txt.gz*).

Bug fixes:

* Fixed bug resulting in relative abundances being written in Gibbs samples output (*\<output-prefix\>_gibbs.txt.gz*) instead of read counts.