### PR TITLE
Added support for r-index, partial matching and improved the noise estimates (first release). 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ add_library(${PROJECT_NAME}
   src/path_abundance_estimator.cpp
   src/threaded_output_writer.cpp
   src/io/register_libvg_io.cpp 
-  src/io/register_loader_saver_gbwt.cpp 
+  src/io/register_loader_saver_gbwt.cpp
+  src/io/register_loader_saver_r_index.cpp 
   src/io/register_loader_saver_xg.cpp
 )
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,28 @@ A docker container of the latest commit to master is available on [Docker Hub](h
 rpvg -g graph.xg -p paths.gbwt -a alignments.gam -o rpvg_results -i <inference-model>
 ```
 
-The prefix used for all output files are given using `-o`. The number of threads can be given using `-t`.
+The prefix used for all output files are given using `-o`. The number of threads can be given using `-t`. 
+
+####Paths:
+
+The paths to be used for inference should be compressed and indexed using the [GBWT](https://github.com/jltsiren/gbwt). To decrease the computation time of *rpvg* it is recommeded that a [r-index](https://github.com/jltsiren/gbwt/wiki/Fast-Locate) of the paths is supplied together with the GBWT index. `vg gbwt` as part of the [vg toolkit](https://github.com/vgteam/vg) can be used to construct the r-index from a GBWT index. The name of the r-index should be the same as the GBWT index with an added *.ri* extension (e.g. *paths.gbwt.ri*).
 
 #### Inference models:
 
 The method currently contains four different inference models. Each model have been written with a particular path type and corresponding inference problem in mind:
 
-* `haplotypes`: Infers haplotype/diplotype/... posterior probabilities. For diploid ploidy it uses a branch and bound like algorithm to infer the most probable combination of haplotypes. A faster less accurate Gibbs sampling scheme can be enabled using `--use-hap-gibbs`, which scales much better for higher ploidies. The maximum ploidy can be given using `-y`.
+* `haplotypes`: Infers haplotype/diplotype/... posterior probabilities. For diploid ploidy it uses a branch and bound like algorithm to infer the most probable combination of haplotypes. A faster, less accurate Gibbs sampling scheme can be enabled using `--use-hap-gibbs`, which scales much better for higher ploidies. The maximum ploidy can be given using `-y`.
 
 * `transcripts`: Infers abundances using a Expectation Maximization (EM) algorithm.
 
-* `strains`: Infers abundances using a combination of weighted minimim path cover and EM. **Note that this algorithm have not yet been properly evaluated**.
+* `strains`: Infers abundances using a combination of weighted minimum path cover and EM. **Note that this algorithm has not yet been properly evaluated**.
 
-* `haplotype-transcripts`: Infers abundances using a combination of haplotype sampling and EM. The most probable haplotype combinations are inferred using the same algorithm as used in the `haplotypes` inference model. By default the haplotypes are inferred independently for each transcript, however equivalent haplotype estimates across clustered transcripts can be enforced using the `--equal-haps` option. The inference algorithm requires a file (`-f`) containing the transcript origin of each path (`--write-info` output from *vg rna*). 
+* `haplotype-transcripts`: Infers abundances using a combination of haplotype sampling and EM. The most probable haplotype combinations are inferred using the same algorithm as used in the `haplotypes` inference model. By default, equivalent haplotypes are inferred for all clustered transcripts, however independent inference of haplotypes for each transcript can be enabled using the `--ind-hap-inference` option. The inference algorithm requires a file (`-f`) containing the transcript origin of each path (`--write-info` output from *vg rna*). 
 
 #### Alignment types:
 
-* Use `-e` if the reads are from a stand-specific protocol. Supports the following library types: 
-  * Use value `fr` when the first read is from the forward stand and the second read is from the reverse strand.
+* Use `-e` if the reads are from a strand-specific protocol. Supports the following library types: 
+  * Use value `fr` when the first read is from the forward strand and the second read is from the reverse strand.
   * Use value `rf` when the first read is from the reverse stand and the second read is from the forward strand.
 * Use `-u` if the input alignments are single-path (*.gam*) format. Default is multipath alignments from *vg mpmap*.
 * Use `-s` for single-end reads. Note that the fragment length distribution will still be used for calculating the effective path length.

--- a/src/alignment_path.cpp
+++ b/src/alignment_path.cpp
@@ -1,32 +1,80 @@
 
+#include "gbwt/fast_locate.h"
+
 #include "alignment_path.hpp"
 
 #include <algorithm>
 #include <numeric>
 
-AlignmentPath::AlignmentPath(const uint32_t seq_length_in, const uint32_t min_mapq_in, const uint32_t score_sum_in, const bool is_multimap_in, const gbwt::SearchState & search_state_in) : seq_length(seq_length_in), min_mapq(min_mapq_in), is_multimap(is_multimap_in), score_sum(score_sum_in), search_state(search_state_in) {}
+AlignmentPath::AlignmentPath(const pair<gbwt::SearchState, gbwt::size_type> & gbwt_search_in, const bool is_multimap_in, const uint32_t frag_length_in, const uint32_t min_mapq_in, const int32_t score_sum_in) : gbwt_search(gbwt_search_in), is_multimap(is_multimap_in), frag_length(frag_length_in), min_mapq(min_mapq_in), score_sum(score_sum_in) {}
 
-AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bool is_multimap_in) : seq_length(align_path_in.seq_length), min_mapq(align_path_in.min_mapq), score_sum(align_path_in.scoreSum()), search_state(align_path_in.search_state), is_multimap(is_multimap_in) {}
+AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bool is_multimap_in) : gbwt_search(align_path_in.gbwt_search), is_multimap(is_multimap_in), frag_length(align_path_in.fragmentLength()), min_mapq(align_path_in.minMappingQuality()), score_sum(align_path_in.scoreSum()) {}
 
 vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool is_multimap) {
 
     vector<AlignmentPath> align_paths;
     align_paths.reserve(align_search_paths.size());
 
+    double noise_prob = 1;   
+
     for (auto & align_search_path: align_search_paths) {
 
-        if (align_search_path.complete()) {
+        if (align_search_path.gbwt_search.first.empty()) {
 
-            align_paths.emplace_back(align_search_path, is_multimap);
+            assert(align_search_path.insert_length == 0);
+            assert(!align_search_path.read_align_stats.empty());
+            assert(!align_search_path.isInternal());
+
+            double non_noise_prob = 1;
+
+            for (auto & read_align_stats: align_search_path.read_align_stats) {
+
+                const double read_error_prob = 1 / (1 + exp(read_align_stats.score * Utils::noise_score_log_base));
+                non_noise_prob *= (1 - read_error_prob);
+            }
+
+            assert(non_noise_prob < 1 || Utils::doubleCompare(non_noise_prob, 1));
+            assert(non_noise_prob > 0 || Utils::doubleCompare(non_noise_prob, 0));
+
+            noise_prob = min(noise_prob, 1 - non_noise_prob);
+
+        } else {
+
+            if (align_search_path.isComplete()) {
+                
+                align_paths.emplace_back(align_search_path, is_multimap);
+                assert(align_paths.front().min_mapq == align_paths.back().min_mapq);
+            }
         }
     }
 
+    sort(align_paths.rbegin(), align_paths.rend());
+
+    if (!align_paths.empty()) {
+
+        if (Utils::doubleCompare(noise_prob, 0)) {
+
+            align_paths.emplace_back(make_pair(gbwt::SearchState(), gbwt::FastLocate::NO_POSITION), is_multimap, 0, align_paths.front().min_mapq, numeric_limits<int32_t>::lowest());
+
+        } else {
+
+            align_paths.emplace_back(make_pair(gbwt::SearchState(), gbwt::FastLocate::NO_POSITION), is_multimap, 0, align_paths.front().min_mapq, Utils::doubleToInt(log(noise_prob) / Utils::noise_score_log_base));
+        }
+
+        assert(align_paths.back().score_sum <= 0);
+    }
+
+    align_paths.shrink_to_fit();
     return align_paths;
 }
 
 bool operator==(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
 
-    return (lhs.seq_length == rhs.seq_length && lhs.min_mapq == rhs.min_mapq && lhs.score_sum == rhs.score_sum && lhs.is_multimap == rhs.is_multimap && lhs.search_state == rhs.search_state);
+    return (lhs.gbwt_search == rhs.gbwt_search && 
+            lhs.is_multimap == rhs.is_multimap && 
+            lhs.frag_length == rhs.frag_length && 
+            lhs.min_mapq == rhs.min_mapq && 
+            lhs.score_sum == rhs.score_sum);
 }
 
 bool operator!=(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
@@ -36,9 +84,29 @@ bool operator!=(const AlignmentPath & lhs, const AlignmentPath & rhs) {
 
 bool operator<(const AlignmentPath & lhs, const AlignmentPath & rhs) { 
 
-    if (lhs.seq_length != rhs.seq_length) {
+    if (lhs.gbwt_search.first.node != rhs.gbwt_search.first.node) {
 
-        return (lhs.seq_length < rhs.seq_length);    
+        return (lhs.gbwt_search.first.node < rhs.gbwt_search.first.node);    
+    } 
+
+    if (lhs.gbwt_search.first.range != rhs.gbwt_search.first.range) {
+
+        return (lhs.gbwt_search.first.range < rhs.gbwt_search.first.range);    
+    } 
+
+    if (lhs.gbwt_search.second != rhs.gbwt_search.second) {
+
+        return (lhs.gbwt_search.second < rhs.gbwt_search.second);    
+    } 
+
+    if (lhs.is_multimap != rhs.is_multimap) {
+
+        return (lhs.is_multimap < rhs.is_multimap);    
+    } 
+
+    if (lhs.frag_length != rhs.frag_length) {
+
+        return (lhs.frag_length < rhs.frag_length);    
     } 
 
     if (lhs.min_mapq != rhs.min_mapq) {
@@ -51,32 +119,18 @@ bool operator<(const AlignmentPath & lhs, const AlignmentPath & rhs) {
         return (lhs.score_sum < rhs.score_sum);    
     } 
 
-    if (lhs.is_multimap != rhs.is_multimap) {
-
-        return (lhs.is_multimap < rhs.is_multimap);    
-    } 
-
-    if (lhs.search_state.node != rhs.search_state.node) {
-
-        return (lhs.search_state.node < rhs.search_state.node);    
-    } 
-
-    if (lhs.search_state.range != rhs.search_state.range) {
-
-        return (lhs.search_state.range < rhs.search_state.range);    
-    } 
-
     return false;
 }
 
 ostream & operator<<(ostream & os, const AlignmentPath & align_path) {
 
-    os << align_path.seq_length;
+    os << gbwt::Node::id(align_path.gbwt_search.first.node);
+    os << " | " << align_path.gbwt_search.first.range;
+    os << " | " << align_path.gbwt_search.second;
+    os << " | " << align_path.is_multimap;
+    os << " | " << align_path.frag_length;
     os << " | " << align_path.min_mapq;
     os << " | " << align_path.score_sum;
-    os << " | " << align_path.is_multimap;
-    os << " | " << gbwt::Node::id(align_path.search_state.node);
-    os << " | " << align_path.search_state.range.first << " " << align_path.search_state.range.second;
 
     return os;
 }
@@ -93,43 +147,455 @@ ostream & operator<<(ostream & os, const vector<AlignmentPath> & align_path) {
     return os;
 }
 
+
+InternalAlignment::InternalAlignment() {
+
+    is_internal = false;
+    penalty = 0;
+    offset = 0;
+
+    max_offset = 0;    
+}
+
+bool operator==(const InternalAlignment & lhs, const InternalAlignment & rhs) { 
+
+    return (lhs.is_internal == rhs.is_internal && 
+            lhs.penalty == rhs.penalty && 
+            lhs.offset == rhs.offset && 
+            lhs.max_offset == rhs.max_offset);
+}
+
+bool operator!=(const InternalAlignment & lhs, const InternalAlignment & rhs) { 
+
+    return !(lhs == rhs);
+}
+
+bool operator<(const InternalAlignment & lhs, const InternalAlignment & rhs) { 
+
+    if (lhs.is_internal != rhs.is_internal) {
+
+        return (lhs.is_internal < rhs.is_internal);    
+    } 
+
+    if (lhs.penalty != rhs.penalty) {
+
+        return (lhs.penalty < rhs.penalty);    
+    } 
+
+    if (lhs.offset != rhs.offset) {
+
+        return (lhs.offset < rhs.offset);    
+    } 
+
+    if (lhs.max_offset != rhs.max_offset) {
+
+        return (lhs.max_offset < rhs.max_offset);    
+    } 
+
+    return false;
+}
+
+ostream & operator<<(ostream & os, const InternalAlignment & internal_align) {
+
+    os << internal_align.is_internal;
+    os << "," << internal_align.penalty;
+    os << "," << internal_align.offset;
+    os << "," << internal_align.max_offset;
+
+    return os;
+}
+
+
+AlignmentStats::AlignmentStats() {
+
+    mapq = 0;
+    score = 0;
+
+    length = 0;
+    complete = false;
+
+    left_softclip_length = 0;
+    right_softclip_length = 0;
+
+    internal_end_next_node = gbwt::ENDMARKER;
+}
+
+void AlignmentStats::updateLeftSoftclipLength(const vg::Path & path) {
+
+    auto mapping_it = path.mapping().cbegin();
+    assert(mapping_it != path.mapping().cend());
+
+    assert(mapping_it->edit_size() > 0);
+    const vg::Edit & first_edit = mapping_it->edit(0);
+
+    if (first_edit.from_length() == 0) {
+
+        left_softclip_length = first_edit.to_length();   
+    
+    } else {
+
+        left_softclip_length = 0;
+    } 
+}
+
+void AlignmentStats::updateRightSoftclipLength(const vg::Path & path) {
+
+    auto mapping_rit = path.mapping().rbegin();
+    assert(mapping_rit != path.mapping().rend());   
+
+    assert(mapping_rit->edit_size() > 0);
+    const vg::Edit & last_edit = mapping_rit->edit(mapping_rit->edit_size() - 1);
+
+    if (last_edit.from_length() == 0) {
+
+        right_softclip_length = last_edit.to_length();   
+
+    } else {
+
+        right_softclip_length = 0;
+    }
+}
+
+bool AlignmentStats::isInternal() const {
+
+    return (internal_start.is_internal || internal_end.is_internal);
+}
+
+uint32_t AlignmentStats::internalPenalty() const {
+
+    return (internal_start.penalty + internal_end.penalty);
+}
+
+uint32_t AlignmentStats::maxInternalOffset() const {
+
+    return max(internal_start.offset, internal_end.offset);
+}
+
+int32_t AlignmentStats::adjustedScore() const {
+
+    return (score - static_cast<int32_t>(internalPenalty()));
+}
+
+uint32_t AlignmentStats::clippedOffsetLeftBases() const {
+
+    return (left_softclip_length + internal_start.offset);
+}
+
+uint32_t AlignmentStats::clippedOffsetRightBases() const {
+
+    return (right_softclip_length + internal_end.offset);
+}
+
+uint32_t AlignmentStats::clippedOffsetTotalBases() const {
+
+    return (clippedOffsetLeftBases() + clippedOffsetRightBases());
+}
+
+bool operator==(const AlignmentStats & lhs, const AlignmentStats & rhs) { 
+
+    return (lhs.mapq == rhs.mapq && 
+            lhs.score == rhs.score && 
+            lhs.length == rhs.length && 
+            lhs.complete == rhs.complete && 
+            lhs.left_softclip_length == rhs.left_softclip_length && 
+            lhs.right_softclip_length == rhs.right_softclip_length && 
+            lhs.internal_start == rhs.internal_start && 
+            lhs.internal_end == rhs.internal_end && 
+            lhs.internal_end_next_node == rhs.internal_end_next_node);
+}
+
+bool operator!=(const AlignmentStats & lhs, const AlignmentStats & rhs) { 
+
+    return !(lhs == rhs);
+}
+
+bool operator<(const AlignmentStats & lhs, const AlignmentStats & rhs) { 
+
+    if (lhs.mapq != rhs.mapq) {
+
+        return (lhs.mapq < rhs.mapq);    
+    } 
+
+    if (lhs.score != rhs.score) {
+
+        return (lhs.score < rhs.score);    
+    } 
+
+    if (lhs.length != rhs.length) {
+
+        return (lhs.length < rhs.length);    
+    } 
+
+    if (lhs.complete != rhs.complete) {
+
+        return (lhs.complete < rhs.complete);    
+    } 
+
+    if (lhs.left_softclip_length != rhs.left_softclip_length) {
+
+        return (lhs.left_softclip_length < rhs.left_softclip_length);    
+    } 
+
+   if (lhs.right_softclip_length != rhs.right_softclip_length) {
+
+        return (lhs.right_softclip_length < rhs.right_softclip_length);    
+    } 
+
+    if (lhs.internal_start != rhs.internal_start) {
+
+        return (lhs.internal_start < rhs.internal_start);    
+    } 
+
+    if (lhs.internal_end != rhs.internal_end) {
+
+        return (lhs.internal_end < rhs.internal_end);    
+    } 
+
+    if (lhs.internal_end_next_node != rhs.internal_end_next_node) {
+
+        return (lhs.internal_end_next_node < rhs.internal_end_next_node);    
+    } 
+
+    return false;
+}
+
+ostream & operator<<(ostream & os, const AlignmentStats & read_align_stats) {
+
+    os << read_align_stats.mapq;
+    os << "," << read_align_stats.score;
+    os << "," << read_align_stats.length;
+    os << "," << read_align_stats.complete;
+    os << "," << read_align_stats.left_softclip_length;
+    os << "," << read_align_stats.right_softclip_length;
+    os << ",(" << read_align_stats.internal_start << ")";
+    os << ",(" << read_align_stats.internal_end << ")";
+    os << "," << read_align_stats.internal_end_next_node;
+
+    return os;
+}
+
+
 AlignmentSearchPath::AlignmentSearchPath() {
 
-    path_end_pos = 0;
-    seq_start_offset = 0;
-    seq_end_offset = 0;
-    seq_length = 0;
-    min_mapq = std::numeric_limits<uint32_t>::max();
+    assert(gbwt_search.first.empty());
+    gbwt_search.second = gbwt::FastLocate::NO_POSITION;
+    
+    start_offset = 0;
+    end_offset = 0;
+
+    insert_length = 0;
 }
 
-uint32_t AlignmentSearchPath::scoreSum() const {
+uint32_t AlignmentSearchPath::fragmentLength() const {
 
-    return max(0, accumulate(scores.begin(), scores.end(), 0));
+    assert(!read_align_stats.empty());
+    assert(read_align_stats.size() <= 2);
+
+    if (read_align_stats.size() == 1) {
+
+        assert(insert_length >= 0);
+
+        if (insert_length == 0) {
+
+            return read_align_stats.front().length;
+        
+        } else {
+
+            int32_t frag_length = read_align_stats.front().length + insert_length;
+            assert(frag_length >= 0);
+
+            assert(read_align_stats.front().clippedOffsetRightBases() <= frag_length);
+            return frag_length - read_align_stats.front().clippedOffsetRightBases();
+        }
+
+    } else {
+
+        assert(read_align_stats.size() == 2);
+
+        int32_t frag_length = read_align_stats.front().length + read_align_stats.back().length + insert_length;
+        assert(frag_length >= 0);
+
+        assert(read_align_stats.front().clippedOffsetRightBases() + read_align_stats.back().clippedOffsetLeftBases() <= frag_length);
+        return (frag_length - read_align_stats.front().clippedOffsetRightBases() - read_align_stats.back().clippedOffsetLeftBases());
+    }
 }
 
-bool AlignmentSearchPath::complete() const {
+uint32_t AlignmentSearchPath::minMappingQuality() const {
 
-    if (path.empty() || path_end_pos != path.size()) {
+    uint32_t min_mapq = std::numeric_limits<uint32_t>::max();
+    assert(!read_align_stats.empty());
 
-        return false;
+    for (auto & stats: read_align_stats) {
+
+        min_mapq = min(min_mapq, stats.mapq);
     }
 
-    assert(search_state.node == path.back());
+    return min_mapq;
+}
+
+int32_t AlignmentSearchPath::scoreSum() const {
+
+    int32_t score_sum = 0;
+    assert(!read_align_stats.empty());
+
+    for (auto & stats: read_align_stats) {
+
+        score_sum += stats.adjustedScore();
+    }
+
+    return score_sum;
+}
+
+double AlignmentSearchPath::minOptimalScoreFraction(const vector<int32_t> & optimal_align_scores) const {
+
+    double min_optim_score_frac = 1;
+
+    assert(!read_align_stats.empty());
+    assert(optimal_align_scores.size() == read_align_stats.size());
+
+    for (size_t i = 0; i < read_align_stats.size(); ++i) {
+
+        assert(read_align_stats.at(i).adjustedScore() <= optimal_align_scores.at(i));
+        min_optim_score_frac = min(min_optim_score_frac, read_align_stats.at(i).adjustedScore() / static_cast<double>(optimal_align_scores.at(i)));
+    }
+
+    return max(0.0, min_optim_score_frac);
+}
+
+double AlignmentSearchPath::maxSoftclipFraction() const {
+
+    double max_softclip_frac = 0;
+    assert(!read_align_stats.empty());
+
+    for (auto & stats: read_align_stats) {
+
+        assert(stats.left_softclip_length + stats.right_softclip_length <= stats.length);
+        max_softclip_frac = max(max_softclip_frac, (stats.left_softclip_length + stats.right_softclip_length) / static_cast<double>(stats.length));
+    }
+
+    return max_softclip_frac;
+}
+
+bool AlignmentSearchPath::isComplete() const {
+
+    for (auto & stats: read_align_stats) {
+
+        if (!stats.complete) {
+
+            return false;
+        }
+    }
 
     return true;
+}
+
+bool AlignmentSearchPath::isInternal() const {
+
+    for (auto & stats: read_align_stats) {
+
+        if (stats.isInternal()) {
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+void AlignmentSearchPath::clear() {
+
+    path.clear();
+
+    gbwt_search.first = gbwt::SearchState();
+    assert(gbwt_search.first.empty());
+
+    gbwt_search.second = gbwt::FastLocate::NO_POSITION;
+}
+
+bool operator==(const AlignmentSearchPath & lhs, const AlignmentSearchPath & rhs) { 
+
+    return (lhs.path == rhs.path && 
+            lhs.gbwt_search == rhs.gbwt_search && 
+            lhs.start_offset == rhs.start_offset && 
+            lhs.end_offset == rhs.end_offset && 
+            lhs.insert_length == rhs.insert_length && 
+            lhs.read_align_stats == rhs.read_align_stats);
+}
+
+bool operator!=(const AlignmentSearchPath & lhs, const AlignmentSearchPath & rhs) { 
+
+    return !(lhs == rhs);
+}
+
+bool operator<(const AlignmentSearchPath & lhs, const AlignmentSearchPath & rhs) { 
+
+    if (lhs.path.size() != rhs.path.size()) {
+
+        return (lhs.path.size() < rhs.path.size());    
+    }
+
+    for (size_t i = 0; i < lhs.path.size(); ++i) {
+
+        if (lhs.path.at(i) != rhs.path.at(i)) {
+
+            return (lhs.path.at(i) < rhs.path.at(i));    
+        } 
+    }
+
+    if (lhs.gbwt_search.first.node != rhs.gbwt_search.first.node) {
+
+        return (lhs.gbwt_search.first.node < rhs.gbwt_search.first.node);    
+    } 
+
+    if (lhs.gbwt_search.first.range != rhs.gbwt_search.first.range) {
+
+        return (lhs.gbwt_search.first.range < rhs.gbwt_search.first.range);    
+    } 
+
+    if (lhs.gbwt_search.second != rhs.gbwt_search.second) {
+
+        return (lhs.gbwt_search.second < rhs.gbwt_search.second);    
+    } 
+
+    if (lhs.insert_length != rhs.insert_length) {
+
+        return (lhs.insert_length < rhs.insert_length);    
+    } 
+
+    if (lhs.scoreSum() != rhs.scoreSum()) {
+
+        return (lhs.scoreSum() < rhs.scoreSum());    
+    } 
+
+    if (lhs.read_align_stats != rhs.read_align_stats) {
+
+        return (lhs.read_align_stats < rhs.read_align_stats);    
+    } 
+
+    if (lhs.start_offset != rhs.start_offset) {
+
+        return (lhs.start_offset < rhs.start_offset);    
+    } 
+
+    if (lhs.end_offset != rhs.end_offset) {
+
+        return (lhs.end_offset < rhs.end_offset);    
+    } 
+
+    return false;
 }
 
 ostream & operator<<(ostream & os, const AlignmentSearchPath & align_search_path) {
 
     os << "(" << align_search_path.path << ")";
-    os << " | " << align_search_path.path_end_pos;
-    os << " | " << align_search_path.seq_start_offset;
-    os << " | " << align_search_path.seq_end_offset;
-    os << " | " << gbwt::Node::id(align_search_path.search_state.node);
-    os << " | " << align_search_path.search_state.size();
-    os << " | " << align_search_path.seq_length;
-    os << " | (" << align_search_path.min_mapq << ")";
-    os << " | (" << align_search_path.scores << ")";
+    os << " | " << gbwt::Node::id(align_search_path.gbwt_search.first.node);
+    os << " | " << align_search_path.gbwt_search.first.size();
+    os << " | " << align_search_path.gbwt_search.second;
+    os << " | " << align_search_path.start_offset;    
+    os << " | " << align_search_path.end_offset;
+    os << " | " << align_search_path.insert_length;
+    os << " | (" << align_search_path.read_align_stats << ")";
 
     return os;
 }

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -2,20 +2,18 @@
 #include "alignment_path_finder.hpp"
 
 #include <assert.h>
+#include <stack>
 
 #include "utils.hpp"
 
 //#define debug
 
+static const int32_t max_score_diff = (Utils::default_match + Utils::default_mismatch) * 4;
+static const int32_t max_noise_score_diff = (Utils::default_match + Utils::default_mismatch) * 2;
+
 
 template<class AlignmentType>
-AlignmentPathFinder<AlignmentType>::AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const uint32_t max_pair_seq_length_in) : paths_index(paths_index_in), library_type(library_type_in), max_pair_seq_length(max_pair_seq_length_in) {}
-
-template<class AlignmentType>
-void AlignmentPathFinder<AlignmentType>::setMaxPairSeqLength(const uint32_t max_pair_seq_length_in) {
-
-    max_pair_seq_length = max_pair_seq_length_in;
-}
+AlignmentPathFinder<AlignmentType>::AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const double min_best_score_filter_in) : paths_index(paths_index_in), library_type(library_type_in), max_pair_frag_length(max_pair_frag_length_in), max_partial_offset(max_partial_offset_in), est_missing_noise_prob(est_missing_noise_prob_in), min_best_score_filter(min_best_score_filter_in) {}
         
 template<class AlignmentType>
 bool AlignmentPathFinder<AlignmentType>::alignmentHasPath(const vg::Alignment & alignment) const {
@@ -32,17 +30,70 @@ bool AlignmentPathFinder<AlignmentType>::alignmentHasPath(const vg::MultipathAli
 template<class AlignmentType>
 bool AlignmentPathFinder<AlignmentType>::alignmentStartInGraph(const AlignmentType & alignment) const {
 
-    auto alignment_start_nodes_index = getAlignmentStartNodesIndex(alignment);
+    auto alignment_start_nodes = getAlignmentStartNodes(alignment);
 
-    for (auto & start_node: alignment_start_nodes_index) {
+    for (auto & start_node: alignment_start_nodes) {
 
-        if (!paths_index.hasNodeId(gbwt::Node::id(start_node.first))) {
+        if (!paths_index.hasNodeId(gbwt::Node::id(start_node))) {
 
             return false;
         } 
     } 
 
     return true;
+}
+
+template<class AlignmentType>
+int32_t AlignmentPathFinder<AlignmentType>::alignmentScore(const char & quality) const {
+
+    return Utils::qual_score_matrix.at(25 * quality);
+}
+
+template<class AlignmentType>
+int32_t AlignmentPathFinder<AlignmentType>::alignmentScore(const string & quality, const uint32_t & start_offset, const uint32_t & length) const {
+
+    if (quality.empty()) {
+
+        return length;
+    }
+
+    assert(start_offset + length <= quality.size());
+    int32_t optimal_score = 0;
+
+    for (size_t i = start_offset; i < start_offset + length; ++i) {
+
+        optimal_score += alignmentScore(quality.at(i));
+    } 
+
+    return optimal_score;
+}
+
+template<class AlignmentType>
+int32_t AlignmentPathFinder<AlignmentType>::optimalAlignmentScore(const string & quality, const uint32_t seq_length) const {
+
+    if (quality.empty()) {
+
+        return seq_length * Utils::default_match + 2 * Utils::default_full_length_bonus;
+    } 
+
+    assert(quality.size() == seq_length);
+
+    int32_t optimal_score = alignmentScore(quality, 0, seq_length);
+    optimal_score += Utils::qual_full_length_bonuses.at(quality.front()) + Utils::qual_full_length_bonuses.at(quality.back());
+
+    return optimal_score;
+}
+
+template<class AlignmentType>
+int32_t AlignmentPathFinder<AlignmentType>::optimalAlignmentScore(const vg::Alignment & alignment) const {
+
+    return optimalAlignmentScore(alignment.quality(), alignment.sequence().size());
+}
+
+template<class AlignmentType>
+int32_t AlignmentPathFinder<AlignmentType>::optimalAlignmentScore(const vg::MultipathAlignment & alignment) const {
+
+    return optimalAlignmentScore(alignment.quality(), alignment.sequence().size());
 }
 
 template<class AlignmentType>
@@ -71,25 +122,22 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 
     if (library_type == "fr") {
 
-        align_search_paths = extendAlignmentPath(AlignmentSearchPath(), alignment);
+        findAlignmentSearchPaths(&align_search_paths, alignment);
 
     } else if (library_type == "rf") {
 
-        AlignmentType alignment_rc = lazy_reverse_complement_alignment(alignment, node_length_func);
-        align_search_paths = extendAlignmentPath(AlignmentSearchPath(), alignment_rc);
+        AlignmentType alignment_rc = Utils::lazy_reverse_complement_alignment(alignment, node_length_func);
+        findAlignmentSearchPaths(&align_search_paths, alignment_rc);
 
     } else {
 
         assert(library_type == "unstranded");
-        align_search_paths = extendAlignmentPath(AlignmentSearchPath(), alignment);
+        findAlignmentSearchPaths(&align_search_paths, alignment);
 
-        if (!paths_index.index().bidirectional()) {
+        if (!paths_index.bidirectional()) {
 
-            AlignmentType alignment_rc = lazy_reverse_complement_alignment(alignment, node_length_func);
-            auto align_search_paths_rc = extendAlignmentPath(AlignmentSearchPath(), alignment_rc);
-
-            align_search_paths.reserve(align_search_paths.size() + align_search_paths_rc.size());
-            align_search_paths.insert(align_search_paths.end(), align_search_paths_rc.begin(), align_search_paths_rc.end());
+            AlignmentType alignment_rc = Utils::lazy_reverse_complement_alignment(alignment, node_length_func);
+            findAlignmentSearchPaths(&align_search_paths, alignment_rc);
         }  
     }
 
@@ -108,175 +156,458 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 }
 
 template<class AlignmentType>
-vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const {
-
-    return extendAlignmentPath(align_search_path, alignment, 0);
-}
-
-template<class AlignmentType>
-vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment, const uint32_t subpath_start_idx) const {
+vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const {
 
     assert(alignment.mapping_quality() >= 0);
+    auto optimal_score = optimalAlignmentScore(alignment);
 
-    vector<AlignmentSearchPath> extended_align_search_path(1, align_search_path);
-    extended_align_search_path.front().min_mapq = min(extended_align_search_path.front().min_mapq, static_cast<uint32_t>(alignment.mapping_quality()));
-    extended_align_search_path.front().scores.emplace_back(alignment.score());
+    vector<AlignmentSearchPath> extended_align_search_paths(1, align_search_path);
     
-    extendAlignmentPath(&extended_align_search_path.front(), alignment.path());
+    extended_align_search_paths.back().read_align_stats.emplace_back(AlignmentStats());
+    AlignmentStats * read_align_stats = &(extended_align_search_paths.back().read_align_stats.back());
 
-    if (extended_align_search_path.front().search_state.empty()) {
+    read_align_stats->mapq = alignment.mapping_quality();
+    read_align_stats->score = alignment.score();
 
-        return vector<AlignmentSearchPath>();
-    
-    } else {
+    read_align_stats->internal_start.max_offset = min(read_align_stats->left_softclip_length + max_partial_offset, static_cast<uint32_t>(alignment.sequence().size()));
+    read_align_stats->internal_end.max_offset = min(read_align_stats->right_softclip_length + max_partial_offset, static_cast<uint32_t>(alignment.sequence().size()));
 
-        return extended_align_search_path;
-    }
-}
+    extendAlignmentSearchPath(&extended_align_search_paths, alignment.path(), true, true, alignment.quality(), alignment.sequence().size(), true);
 
-template<class AlignmentType>
-void AlignmentPathFinder<AlignmentType>::extendAlignmentPath(AlignmentSearchPath * align_search_path, const vg::Path & path) const {
+    int32_t max_align_path_score = 0;
 
-    assert(align_search_path->path_end_pos <= align_search_path->path.size());
-    
-    auto mapping_it = path.mapping().cbegin();
-    assert(mapping_it != path.mapping().cend());
+    for (auto & align_search_path: extended_align_search_paths) {
 
-    if (!align_search_path->path.empty() && align_search_path->path_end_pos == 0) {
+        assert(align_search_path.read_align_stats.back().length <= alignment.sequence().size());
+        assert(!align_search_path.read_align_stats.back().complete);
 
-        if (mapping_it->position().offset() < align_search_path->seq_start_offset) {
+        if ((align_search_path.isInternal() || !est_missing_noise_prob) && align_search_path.gbwt_search.first.empty()) {
 
-            align_search_path->search_state = gbwt::SearchState();
-            assert(align_search_path->search_state.empty());
+            continue;
+        }
 
-            return;  
+        if (align_search_path.read_align_stats.back().length == alignment.sequence().size()) {
+
+            align_search_path.read_align_stats.back().complete = true;
+            max_align_path_score = max(max_align_path_score, align_search_path.scoreSum());
         }
     }
 
-    while (align_search_path->path_end_pos < align_search_path->path.size() && mapping_it != path.mapping().cend()) {
+    assert(max_align_path_score <= optimal_score);
 
-        ++align_search_path->path_end_pos;
+    for (auto & align_search_path: extended_align_search_paths) {
 
-        if (align_search_path->path.at(align_search_path->path_end_pos - 1) != mapping_to_gbwt(*mapping_it)) {
+        if (align_search_path.read_align_stats.back().complete) {
 
-            align_search_path->search_state = gbwt::SearchState();
-            assert(align_search_path->search_state.empty());  
-    
-            return;  
-    
-        } else {
+            const int32_t align_path_score = align_search_path.scoreSum();
+            assert(align_path_score <= max_align_path_score);
 
-            align_search_path->seq_length -= align_search_path->seq_end_offset;
-            align_search_path->seq_end_offset = mapping_it->position().offset() + mapping_from_length(*mapping_it);
-            align_search_path->seq_length += mapping_it->position().offset() + mapping_to_length(*mapping_it);
-        } 
+            if (max_align_path_score - align_path_score > max_score_diff) {
 
-        ++mapping_it;
-    }
-
-    while (mapping_it != path.mapping().cend()) {
-
-        align_search_path->path.emplace_back(mapping_to_gbwt(*mapping_it));
-        ++align_search_path->path_end_pos;
-        align_search_path->seq_end_offset = mapping_it->position().offset() + mapping_from_length(*mapping_it);
-
-        if (align_search_path->path.size() == 1) {
-
-            assert(align_search_path->search_state.node == gbwt::ENDMARKER);
-            assert(align_search_path->seq_length == 0);
-
-            align_search_path->seq_start_offset = mapping_it->position().offset();
-            align_search_path->search_state = paths_index.index().find(align_search_path->path.back());
-        
-        } else {
-
-            align_search_path->search_state = paths_index.index().extend(align_search_path->search_state, align_search_path->path.back());                
-        }
-
-        align_search_path->seq_length += mapping_to_length(*mapping_it);
-        ++mapping_it;
-
-        if (align_search_path->search_state.empty()) {
-
-            break;
+                align_search_path.read_align_stats.back().complete = false;
+            }
         }
     }
-}
 
-template<class AlignmentType>
-vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment) const {
+    if (filterAlignmentSearchPaths(extended_align_search_paths, vector<int32_t>({optimal_score}))) {
 
-    vector<AlignmentSearchPath> extended_align_search_paths;
+        extended_align_search_paths.emplace_back(AlignmentSearchPath());
+        extended_align_search_paths.back().path.emplace_back(gbwt::ENDMARKER);
 
-    for (auto & start_idx: alignment.start()) {
+        extended_align_search_paths.back().read_align_stats.emplace_back(AlignmentStats());
+        AlignmentStats * error_read_align_stats = &(extended_align_search_paths.back().read_align_stats.back());
 
-        auto cur_extended_align_search_paths = extendAlignmentPath(align_search_path, alignment, start_idx);
-        extended_align_search_paths.insert(extended_align_search_paths.end(), cur_extended_align_search_paths.begin(), cur_extended_align_search_paths.end());
+        error_read_align_stats->mapq = alignment.mapping_quality();
+        error_read_align_stats->score = numeric_limits<int32_t>::max();
+
+        error_read_align_stats->length = alignment.sequence().size();
+        error_read_align_stats->complete = true;
     }
 
     return extended_align_search_paths;
 }
 
 template<class AlignmentType>
-vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment, const uint32_t subpath_start_idx) const {
+void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<AlignmentSearchPath> * align_search_paths, const vg::Path & path, const bool is_first_path, const bool is_last_path, const string & quality, const uint32_t seq_length, const bool add_internal_start) const {
 
-    assert(alignment.mapping_quality() >= 0);
+    assert(align_search_paths->size() == 1);
+    assert(!align_search_paths->front().read_align_stats.empty());
 
-    vector<AlignmentSearchPath> extended_align_search_path(1, align_search_path);
-    extended_align_search_path.front().min_mapq = min(extended_align_search_path.front().min_mapq, static_cast<uint32_t>(alignment.mapping_quality()));
-    extended_align_search_path.front().scores.emplace_back(0);
+    if (is_first_path) {
 
-    extendAlignmentPaths(&extended_align_search_path, alignment.subpath(), subpath_start_idx);
-            
-    return extended_align_search_path;
-}
-
-template<class AlignmentType>
-void AlignmentPathFinder<AlignmentType>::extendAlignmentPaths(vector<AlignmentSearchPath> * align_search_paths, const google::protobuf::RepeatedPtrField<vg::Subpath> & subpaths, const uint32_t subpath_start_idx) const {
-
-    std::queue<pair<AlignmentSearchPath, uint32_t> > align_search_paths_queue;
-
-    for (auto & align_search_path: *align_search_paths) {
-
-        align_search_paths_queue.push(make_pair(align_search_path, subpath_start_idx));
+        align_search_paths->front().read_align_stats.back().updateLeftSoftclipLength(path);
     }
 
-    align_search_paths->clear();
+    if (is_last_path) {
 
-    // Perform depth-first alignment path extension.
-    while (!align_search_paths_queue.empty()) {
+        align_search_paths->front().read_align_stats.back().updateRightSoftclipLength(path);
+    }
 
-        auto & cur_align_search_path = align_search_paths_queue.front();
+    uint32_t last_internal_start_idx = 0;
 
-        const vg::Subpath & subpath = subpaths.Get(cur_align_search_path.second);
+    auto mapping_it = path.mapping().cbegin();
+    assert(mapping_it != path.mapping().cend());
 
-        cur_align_search_path.first.scores.back() += subpath.score();
-        extendAlignmentPath(&cur_align_search_path.first, subpath.path());
+    auto end_mapping_it = path.mapping().cend();
+    --end_mapping_it;
 
-        if (cur_align_search_path.first.path.empty() || !cur_align_search_path.first.search_state.empty()) {
+    while (mapping_it != path.mapping().cend()) {
 
-            if (subpath.next_size() > 0 || subpath.connection_size() > 0) {
+        auto cur_node = Utils::mapping_to_gbwt(*mapping_it);
+        auto mapping_read_length = Utils::mapping_to_length(*mapping_it);
 
-                for (auto & next_subpath_idx: subpath.next()) {
+        const bool is_last_mapping = (is_last_path && mapping_it == end_mapping_it);
 
-                    align_search_paths_queue.push(make_pair(cur_align_search_path.first, next_subpath_idx));
-                }
+        AlignmentSearchPath main_align_search_path;
 
-                for (auto & connection: subpath.connection()) {
+        if (max_partial_offset > 0 && !align_search_paths->front().gbwt_search.first.empty() && !align_search_paths->front().read_align_stats.back().internal_end.is_internal) {
 
-                    assert(connection.score() <= 0);
-                    cur_align_search_path.first.scores.back() += connection.score();
+            assert(align_search_paths->front().read_align_stats.back().internal_end.offset == 0);
+            assert(align_search_paths->front().read_align_stats.back().length <= seq_length);
 
-                    align_search_paths_queue.push(make_pair(cur_align_search_path.first, connection.next()));
-                }
+            if (seq_length - align_search_paths->front().read_align_stats.back().length <= align_search_paths->front().read_align_stats.back().internal_end.max_offset) {
 
-            } else {
-
-                align_search_paths->emplace_back(cur_align_search_path.first);
+                main_align_search_path = align_search_paths->front();
             }
         }
 
-        align_search_paths_queue.pop();
+        for (auto & align_search_path: *align_search_paths) {
+
+            if (align_search_path.read_align_stats.back().internal_end.is_internal) {
+
+                assert(max_partial_offset > 0);
+
+                AlignmentStats * internal_end_read_align_stats = &(align_search_path.read_align_stats.back());
+                auto internal_end_new_offset = mapping_read_length;
+
+                if (is_last_mapping) {
+
+                    assert(internal_end_read_align_stats->right_softclip_length <= internal_end_new_offset);
+                    internal_end_new_offset -= internal_end_read_align_stats->right_softclip_length;
+                } 
+
+                internal_end_read_align_stats->internal_end.offset += internal_end_new_offset;
+
+                if (internal_end_read_align_stats->internal_end.offset <= max_partial_offset) {
+                    
+                    internal_end_read_align_stats->internal_end.penalty += alignmentScore(quality, internal_end_read_align_stats->length, internal_end_new_offset);
+                
+                } else {
+
+                    align_search_path.clear();
+                }
+            
+            } else {
+
+                extendAlignmentSearchPath(&align_search_path, *mapping_it);
+            }
+        }
+
+        if (max_partial_offset > 0 && !main_align_search_path.gbwt_search.first.empty()) {
+
+            assert(main_align_search_path.gbwt_search.first.size() >= align_search_paths->front().gbwt_search.first.size());
+
+            if (main_align_search_path.gbwt_search.first.size() > align_search_paths->front().gbwt_search.first.size()) {
+
+                main_align_search_path.read_align_stats.back().internal_end.is_internal = true;
+                main_align_search_path.read_align_stats.back().internal_end.offset = mapping_read_length;
+
+                if (is_last_mapping) {
+
+                    assert(main_align_search_path.read_align_stats.back().right_softclip_length <= main_align_search_path.read_align_stats.back().internal_end.offset);
+                    main_align_search_path.read_align_stats.back().internal_end.offset -= main_align_search_path.read_align_stats.back().right_softclip_length;
+                } 
+
+                if (main_align_search_path.read_align_stats.back().internal_end.offset <= max_partial_offset) {
+
+                    main_align_search_path.read_align_stats.back().internal_end_next_node = cur_node;
+                    main_align_search_path.read_align_stats.back().internal_end.penalty = alignmentScore(quality, main_align_search_path.read_align_stats.back().length, main_align_search_path.read_align_stats.back().internal_end.offset);
+
+                    align_search_paths->emplace_back(main_align_search_path);
+                }
+            }
+        }
+
+        if (max_partial_offset > 0 && add_internal_start && align_search_paths->at(last_internal_start_idx).path.size() > 1 && !align_search_paths->at(last_internal_start_idx).read_align_stats.back().internal_end.is_internal) {
+
+            if (align_search_paths->at(last_internal_start_idx).read_align_stats.back().length <= align_search_paths->at(last_internal_start_idx).read_align_stats.back().internal_start.max_offset) {
+
+                auto internal_start_read_align_stats = align_search_paths->at(last_internal_start_idx).read_align_stats.back();
+                assert(internal_start_read_align_stats.left_softclip_length <= internal_start_read_align_stats.length);
+
+                internal_start_read_align_stats.internal_start.is_internal = true;
+                internal_start_read_align_stats.internal_start.offset = internal_start_read_align_stats.length - internal_start_read_align_stats.left_softclip_length;
+
+                if (internal_start_read_align_stats.internal_start.offset <= max_partial_offset) {
+
+                    AlignmentSearchPath new_start_align_search_path;
+                    extendAlignmentSearchPath(&new_start_align_search_path, *mapping_it);
+
+                    if (!new_start_align_search_path.gbwt_search.first.empty()) {
+
+                        assert(new_start_align_search_path.gbwt_search.first.size() >= align_search_paths->at(last_internal_start_idx).gbwt_search.first.size());
+
+                        if (new_start_align_search_path.gbwt_search.first.size() > align_search_paths->at(last_internal_start_idx).gbwt_search.first.size()) {
+
+                            align_search_paths->emplace_back(new_start_align_search_path);
+                            last_internal_start_idx = align_search_paths->size() - 1;
+
+                            internal_start_read_align_stats.internal_start.penalty = alignmentScore(quality, internal_start_read_align_stats.left_softclip_length, internal_start_read_align_stats.internal_start.offset);
+                            align_search_paths->back().read_align_stats = vector<AlignmentStats>(1, internal_start_read_align_stats);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (auto & align_search_path: *align_search_paths) {
+
+            align_search_path.read_align_stats.back().length += mapping_read_length;
+        }
+
+        ++mapping_it;
+    }
+}
+
+template<class AlignmentType>
+void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(AlignmentSearchPath * align_search_path, const vg::Mapping & mapping) const {
+
+    auto cur_node = Utils::mapping_to_gbwt(mapping);
+
+    if (align_search_path->path.empty()) {
+
+        assert(align_search_path->gbwt_search.first.node == gbwt::ENDMARKER);
+
+        align_search_path->path.emplace_back(cur_node);
+        paths_index.find(&(align_search_path->gbwt_search), cur_node);
+  
+        align_search_path->start_offset = mapping.position().offset();
+
+    } else {
+
+        bool is_cycle_visit = false;
+
+        if (align_search_path->path.back() == cur_node && mapping.position().offset() != align_search_path->end_offset) {
+
+            assert(mapping.position().offset() == 0);
+            is_cycle_visit = true;      
+        }
+
+        if (align_search_path->path.back() != cur_node || is_cycle_visit) {
+
+            align_search_path->path.emplace_back(cur_node);
+
+            if (!align_search_path->gbwt_search.first.empty()) {
+
+                paths_index.extend(&(align_search_path->gbwt_search), cur_node);
+            }
+        } 
+    }
+
+    align_search_path->end_offset = mapping.position().offset() + Utils::mapping_from_length(mapping);
+}
+
+template<class AlignmentType>
+vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment) const {
+
+    assert(alignment.mapping_quality() >= 0);
+    auto optimal_score = optimalAlignmentScore(alignment);
+
+    vector<AlignmentSearchPath> extended_align_search_paths;
+
+    auto left_softclip_lengths = getAlignmentStartSoftclipLengths(alignment);
+    auto right_softclip_lengths = getAlignmentEndSoftclipLengths(alignment);
+
+    auto min_right_softclip_length = *min_element(right_softclip_lengths.begin(), right_softclip_lengths.end());
+    assert(min_right_softclip_length <= alignment.sequence().size());
+
+    auto max_right_softclip_length = *max_element(right_softclip_lengths.begin(), right_softclip_lengths.end());
+    assert(max_right_softclip_length <= alignment.sequence().size());
+
+    vector<pair<int32_t, uint32_t> > start_score_indexes;
+
+    for (auto & start_subpath_idx: alignment.start()) {
+
+        start_score_indexes.emplace_back(alignment.subpath().Get(start_subpath_idx).score(), start_subpath_idx);
+    }
+
+    sort(start_score_indexes.rbegin(), start_score_indexes.rend());
+
+    spp::sparse_hash_map<pair<uint32_t, uint32_t>, int32_t> internal_node_subpaths;
+    int32_t best_align_score = floor(optimal_score * min_best_score_filter);
+
+    for (auto & start_score_idx: start_score_indexes) {
+
+        AlignmentSearchPath init_align_search_path;
+
+        init_align_search_path.read_align_stats.emplace_back(AlignmentStats());
+        AlignmentStats * init_read_align_stats = &(init_align_search_path.read_align_stats.back());
+
+        init_read_align_stats->mapq = alignment.mapping_quality();
+
+        AlignmentStats tpm_read_align_stats;
+        tpm_read_align_stats.updateLeftSoftclipLength(alignment.subpath(start_score_idx.second).path());
+        assert(tpm_read_align_stats.left_softclip_length <= alignment.sequence().size());
+
+        init_read_align_stats->internal_start.max_offset = min(tpm_read_align_stats.left_softclip_length + max_partial_offset, static_cast<uint32_t>(alignment.sequence().size()));
+        init_read_align_stats->internal_end.max_offset = min(max_right_softclip_length + max_partial_offset, static_cast<uint32_t>(alignment.sequence().size()));
+
+        extendAlignmentSearchPaths(&extended_align_search_paths, init_align_search_path, alignment.subpath(), start_score_idx.second, alignment.quality(), alignment.sequence().size(), &internal_node_subpaths, &best_align_score, min_right_softclip_length == 0);
+    }
+
+    assert(best_align_score <= optimal_score);
+
+    for (auto & align_search_path: extended_align_search_paths) {
+
+        assert(align_search_path.read_align_stats.back().complete);
+
+        const int32_t align_path_score = align_search_path.scoreSum();
+        assert(align_path_score <= best_align_score);
+
+        if (best_align_score - align_path_score > max_score_diff) {
+
+            align_search_path.read_align_stats.back().complete = false;
+        }
+    }
+
+    if (filterAlignmentSearchPaths(extended_align_search_paths, vector<int32_t>({optimal_score}))) {
+
+        extended_align_search_paths.emplace_back(AlignmentSearchPath());
+        extended_align_search_paths.back().path.emplace_back(gbwt::ENDMARKER);
+
+        extended_align_search_paths.back().read_align_stats.emplace_back(AlignmentStats());
+        AlignmentStats * error_read_align_stats = &(extended_align_search_paths.back().read_align_stats.back());
+
+        error_read_align_stats->mapq = alignment.mapping_quality();
+        error_read_align_stats->score = numeric_limits<int32_t>::max();
+
+        error_read_align_stats->length = alignment.sequence().size();
+        error_read_align_stats->complete = true;
+    }
+
+    return extended_align_search_paths;
+}
+
+template<class AlignmentType>
+void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPaths(vector<AlignmentSearchPath> * align_search_paths, const AlignmentSearchPath & init_align_search_path, const google::protobuf::RepeatedPtrField<vg::Subpath> & subpaths, const uint32_t start_subpath_idx, const string & quality, const uint32_t seq_length, spp::sparse_hash_map<pair<uint32_t, uint32_t>, int32_t> * internal_node_subpaths, int32_t * best_align_score, const bool has_right_bonus) const {
+
+    stack<pair<AlignmentSearchPath, uint32_t> > align_search_paths_stack;
+    align_search_paths_stack.emplace(init_align_search_path, start_subpath_idx);
+
+    // Perform depth-first alignment path extension.
+    while (!align_search_paths_stack.empty()) {
+
+        vector<AlignmentSearchPath> extended_align_search_paths(1, align_search_paths_stack.top().first);
+        const uint32_t subpath_idx = align_search_paths_stack.top().second;
+
+        align_search_paths_stack.pop();
+
+        const vg::Subpath & subpath = subpaths.Get(subpath_idx);
+        AlignmentSearchPath * extended_align_search_path = &(extended_align_search_paths.front());
+        extended_align_search_path->read_align_stats.back().score += subpath.score();
+
+        uint32_t subpath_length = 0;
+
+        for (auto & mapping: subpath.path().mapping()) {
+
+            subpath_length += Utils::mapping_to_length(mapping);
+        }
+
+        assert(extended_align_search_path->read_align_stats.back().length + subpath_length <= seq_length);
+        const int32_t seq_length_left = seq_length - (extended_align_search_path->read_align_stats.back().length + subpath_length);
+
+        int32_t max_score = extended_align_search_path->read_align_stats.back().score + seq_length_left;
+
+        if (has_right_bonus && subpath.next_size() > 0) {
+
+            max_score += Utils::default_full_length_bonus;
+        }
+
+        if (*best_align_score - max_score > max_score_diff) {
+
+            continue;
+        } 
+
+        bool add_internal_start = false;
+
+        if (max_partial_offset > 0 && extended_align_search_path->read_align_stats.back().length <= extended_align_search_path->read_align_stats.back().internal_start.max_offset) {
+
+            add_internal_start = true;
+
+            assert(extended_align_search_path->read_align_stats.back().left_softclip_length <= extended_align_search_path->read_align_stats.back().length);
+            auto internal_node_subpaths_it = internal_node_subpaths->emplace(make_pair(subpath_idx, extended_align_search_path->read_align_stats.back().length - extended_align_search_path->read_align_stats.back().left_softclip_length), extended_align_search_path->read_align_stats.back().score);
+
+            if (!internal_node_subpaths_it.second) {
+
+                if (extended_align_search_path->read_align_stats.back().score <= internal_node_subpaths_it.first->second) {
+
+                    add_internal_start = false;
+
+                } else {
+
+                    internal_node_subpaths_it.first->second = extended_align_search_path->read_align_stats.back().score;
+                }
+            }
+        
+        } else if (extended_align_search_path->gbwt_search.first.empty()) {
+
+            if (*best_align_score - max_score > max_noise_score_diff) {
+
+                continue;
+            } 
+        }
+
+        extendAlignmentSearchPath(&extended_align_search_paths, subpath.path(), subpath_idx == start_subpath_idx, subpath.next_size() == 0, quality, seq_length, add_internal_start);        
+
+        for (auto & align_search_path: extended_align_search_paths) {
+
+            if (align_search_path.gbwt_search.first.empty()) {
+
+                if (align_search_path.isInternal()) {
+
+                    continue;
+                }
+
+                if (!est_missing_noise_prob && max_partial_offset == 0) {
+
+                    continue;
+                }
+
+                if (!est_missing_noise_prob && align_search_path.read_align_stats.back().length > align_search_path.read_align_stats.back().internal_start.max_offset) {
+
+                    continue;
+                }
+            }
+
+            assert(!align_search_path.path.empty());
+
+            if (subpath.next_size() > 0) {
+
+                vector<pair<int32_t, uint32_t> > next_score_indexes;
+
+                for (auto & next_subpath_idx: subpath.next()) {
+
+                    next_score_indexes.emplace_back(subpaths.Get(next_subpath_idx).score(), next_subpath_idx);
+                }
+
+                sort(next_score_indexes.begin(), next_score_indexes.end());
+
+                for (auto & next_score_idx: next_score_indexes) {
+
+                    align_search_paths_stack.emplace(align_search_path, next_score_idx.second);
+                }
+
+            } else if (subpath.connection_size() == 0) {
+
+                *best_align_score = max(*best_align_score, align_search_path.scoreSum());
+
+                assert(align_search_path.read_align_stats.back().length == seq_length);
+                assert(!align_search_path.read_align_stats.back().complete);
+
+                align_search_path.read_align_stats.back().complete = true;
+                align_search_paths->emplace_back(move(align_search_path));
+            }
+        }
     }
 }
 
@@ -304,28 +635,28 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPat
     vector<AlignmentSearchPath> paired_align_search_paths;
 
     function<size_t(const uint32_t)> node_length_func = [&](const uint32_t node_id) { return paths_index.nodeLength(node_id); };
-    AlignmentType alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_length_func);
+    AlignmentType alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_length_func);
 
     if (library_type == "fr") {
 
-        pairAlignmentPaths(&paired_align_search_paths, alignment_1, alignment_2_rc);
+        findPairedAlignmentSearchPaths(&paired_align_search_paths, alignment_1, alignment_2_rc);
 
     } else if (library_type == "rf") {
 
-        AlignmentType alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_length_func);
-        pairAlignmentPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
+        AlignmentType alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_length_func);
+        findPairedAlignmentSearchPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
 
     } else {
 
         assert(library_type == "unstranded");
 
-        AlignmentType alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_length_func);
-        pairAlignmentPaths(&paired_align_search_paths, alignment_1, alignment_2_rc);
+        AlignmentType alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_length_func);
+        findPairedAlignmentSearchPaths(&paired_align_search_paths, alignment_1, alignment_2_rc);
 
-        if (!paths_index.index().bidirectional()) {
+        if (!paths_index.bidirectional()) {
 
-            AlignmentType alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_length_func);
-            pairAlignmentPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
+            AlignmentType alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_length_func);
+            findPairedAlignmentSearchPaths(&paired_align_search_paths, alignment_2, alignment_1_rc);
         }
     }
 
@@ -344,173 +675,523 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPat
 }
 
 template<class AlignmentType>
-void AlignmentPathFinder<AlignmentType>::pairAlignmentPaths(vector<AlignmentSearchPath> * paired_align_search_paths, const AlignmentType & start_alignment, const AlignmentType & end_alignment) const {
+void AlignmentPathFinder<AlignmentType>::findAlignmentSearchPaths(vector<AlignmentSearchPath> * align_search_paths, const AlignmentType & alignment) const {
 
-    auto start_align_search_paths = extendAlignmentPath(AlignmentSearchPath(), start_alignment);
-    auto end_alignment_start_nodes_index = getAlignmentStartNodesIndex(end_alignment);
+    auto single_align_search_paths = extendAlignmentSearchPath(AlignmentSearchPath(), alignment);
 
-    std::queue<AlignmentSearchPath> paired_align_search_path_queue;
+    if (single_align_search_paths.empty()) {
 
-    for (auto & align_search_path: start_align_search_paths) {
+        return;
+    }
 
-        assert(!align_search_path.search_state.empty());
-        assert(!align_search_path.path.empty());
+    sort(single_align_search_paths.rbegin(), single_align_search_paths.rend());
 
-        align_search_path.seq_length += (paths_index.nodeLength(gbwt::Node::id(align_search_path.search_state.node)) - align_search_path.seq_end_offset);
-        align_search_path.seq_end_offset = paths_index.nodeLength(gbwt::Node::id(align_search_path.search_state.node));
+    double joint_single_align_score = numeric_limits<int32_t>::lowest();
+    double joint_empty_single_align_score = numeric_limits<int32_t>::lowest();
 
-        paired_align_search_path_queue.push(align_search_path);
+    for (size_t i = 0; i < single_align_search_paths.size(); ++i) {
 
-        for (auto & start_nodes: end_alignment_start_nodes_index) {
+        const AlignmentSearchPath & single_search_path = single_align_search_paths.at(i);
+        assert(single_search_path.read_align_stats.size() == 1);
 
-            auto path_it = find(align_search_path.path.begin(), align_search_path.path.end(), start_nodes.first); 
+        if (!single_search_path.isComplete()) {
+
+            continue;
+        }
+
+        assert(!single_search_path.path.empty());
+        assert(single_search_path.read_align_stats.back().length == alignment.sequence().size());
+
+        if (i > 0) {
+
+            if (single_search_path.path == single_align_search_paths.at(i - 1).path) {
+
+                assert(single_search_path.gbwt_search == single_align_search_paths.at(i - 1).gbwt_search);
+                assert(single_search_path.scoreSum() <= single_align_search_paths.at(i - 1).scoreSum());
+
+                continue;
+            }
+        }
+
+        const int32_t score_sum = single_search_path.scoreSum();
+
+        if (single_search_path.gbwt_search.first.empty()) {
+
+            assert(!single_search_path.isInternal());
+            joint_empty_single_align_score  = Utils::add_log(joint_empty_single_align_score, score_sum * Utils::score_log_base);
             
-            auto align_search_path_end = align_search_path.path.end();
-            --align_search_path_end;
+            continue;
+        }
 
-            while (path_it != align_search_path.path.end()) {
+        if (!single_search_path.isInternal()) {
 
-                if (path_it == align_search_path_end) {
+            joint_single_align_score = Utils::add_log(joint_single_align_score, score_sum * Utils::score_log_base);
+        }
 
-                    break;
-                }
+        align_search_paths->emplace_back(move(single_search_path));
+    }
 
-                align_search_path.path_end_pos = path_it - align_search_path.path.begin();
-                auto complete_paired_align_search_paths = extendAlignmentPath(align_search_path, end_alignment, start_nodes.second);
+    align_search_paths->emplace_back(AlignmentSearchPath());
 
-                for (auto & complete_align_search_path: complete_paired_align_search_paths) {
+    align_search_paths->back().read_align_stats.emplace_back(AlignmentStats());
+    align_search_paths->back().read_align_stats.back().score = Utils::doubleToInt((joint_single_align_score - joint_empty_single_align_score) / Utils::noise_score_log_base);
+}
 
-                    if (!complete_align_search_path.search_state.empty() && complete_align_search_path.seq_length <= max_pair_seq_length) {
+template<class AlignmentType>
+void AlignmentPathFinder<AlignmentType>::findPairedAlignmentSearchPaths(vector<AlignmentSearchPath> * paired_align_search_paths, const AlignmentType & start_alignment, const AlignmentType & end_alignment) const {
 
-                        paired_align_search_paths->emplace_back(complete_align_search_path);                         
+    auto start_align_search_paths = extendAlignmentSearchPath(AlignmentSearchPath(), start_alignment);
+    auto end_align_search_paths = extendAlignmentSearchPath(AlignmentSearchPath(), end_alignment);
+
+    if (start_align_search_paths.empty() || end_align_search_paths.empty()) {
+
+        return;
+    }
+
+    sort(start_align_search_paths.rbegin(), start_align_search_paths.rend());
+    sort(end_align_search_paths.rbegin(), end_align_search_paths.rend());
+
+    uint32_t num_unique_end_search_paths = 0;
+    uint32_t end_max_left_softclip_length = 0;
+
+    spp::sparse_hash_map<gbwt::node_type, uint32_t> end_search_paths_nodes;
+    spp::sparse_hash_map<gbwt::node_type, vector<uint32_t> > end_search_paths_start_nodes_index;
+
+    double joint_end_align_score = numeric_limits<int32_t>::lowest();
+    double joint_empty_end_align_score = numeric_limits<int32_t>::lowest();
+
+    for (size_t i = 0; i < end_align_search_paths.size(); ++i) {
+
+        const AlignmentSearchPath & end_search_path = end_align_search_paths.at(i);
+        assert(end_search_path.read_align_stats.size() == 1);
+
+        if (!end_search_path.isComplete()) {
+
+            continue;
+        }
+
+        assert(!end_search_path.path.empty());
+        assert(end_search_path.read_align_stats.back().length == end_alignment.sequence().size());
+
+        if (i > 0) {
+
+            if (end_search_path.path == end_align_search_paths.at(i - 1).path) {
+
+                assert(end_search_path.gbwt_search.first == end_align_search_paths.at(i - 1).gbwt_search.first);
+                assert(end_search_path.scoreSum() <= end_align_search_paths.at(i - 1).scoreSum());
+
+                continue;
+            }
+        }
+
+        const int32_t score_sum = end_search_path.scoreSum();
+
+        if (end_search_path.gbwt_search.first.empty()) {
+
+            assert(!end_search_path.isInternal());
+            joint_empty_end_align_score  = Utils::add_log(joint_empty_end_align_score, score_sum * Utils::score_log_base);
+            
+            continue;
+        }
+
+        if (!end_search_path.isInternal()) {
+
+            joint_end_align_score = Utils::add_log(joint_end_align_score, score_sum * Utils::score_log_base);
+        }
+
+        num_unique_end_search_paths++;
+        end_max_left_softclip_length = max(end_max_left_softclip_length, end_search_path.read_align_stats.back().left_softclip_length);
+
+        for (auto & path_id: end_search_path.path) {
+
+            auto end_search_paths_nodes_it = end_search_paths_nodes.emplace(path_id, 0);
+            end_search_paths_nodes_it.first->second++;
+        }
+
+        auto end_search_paths_start_nodes_index_it = end_search_paths_start_nodes_index.emplace(end_search_path.path.front(), vector<uint32_t>());
+        end_search_paths_start_nodes_index_it.first->second.emplace_back(i);
+    }
+
+    assert(end_max_left_softclip_length <= end_alignment.sequence().size());
+
+    bool end_alignment_in_cycle = false;
+
+    for (auto end_search_paths_start_node: end_search_paths_start_nodes_index) {
+
+        pair<gbwt::SearchState, gbwt::size_type> start_node_gbwt_search;
+        paths_index.find(&start_node_gbwt_search, end_search_paths_start_node.first);
+
+        const uint32_t num_start_node_paths = paths_index.locatePathIds(start_node_gbwt_search).size();
+        assert(num_start_node_paths <= start_node_gbwt_search.first.size());
+
+        if (num_start_node_paths < start_node_gbwt_search.first.size()) {
+
+            end_alignment_in_cycle = true;
+            break;
+        }
+    }
+
+    stack<pair<AlignmentSearchPath, bool> > paired_align_search_path_stack;
+
+    double joint_start_align_score = numeric_limits<int32_t>::lowest();
+    double joint_empty_start_align_score = numeric_limits<int32_t>::lowest();
+
+    for (size_t i = 0; i < start_align_search_paths.size(); ++i) {
+
+        const AlignmentSearchPath & start_search_path = start_align_search_paths.at(i);
+        assert(start_search_path.read_align_stats.size() == 1);
+
+        if (!start_search_path.isComplete()) {
+
+            continue;
+        }
+
+        assert(!start_search_path.path.empty());
+        assert(start_search_path.read_align_stats.back().length == start_alignment.sequence().size());
+
+        if (i > 0) {
+
+            if (start_search_path.path == start_align_search_paths.at(i - 1).path) {
+
+                assert(start_search_path.gbwt_search == start_align_search_paths.at(i - 1).gbwt_search);
+                assert(start_search_path.scoreSum() <= start_align_search_paths.at(i - 1).scoreSum());
+
+                continue;
+            }
+        }
+
+        const int32_t score_sum = start_search_path.scoreSum();
+
+        if (start_search_path.gbwt_search.first.empty()) {
+
+            assert(!start_search_path.isInternal());
+            joint_empty_start_align_score = Utils::add_log(joint_empty_start_align_score, score_sum * Utils::score_log_base);
+
+            continue;
+        } 
+        
+        if (!start_search_path.isInternal()) {
+
+            joint_start_align_score = Utils::add_log(joint_start_align_score, score_sum * Utils::score_log_base);
+        }
+
+        auto node_length = paths_index.nodeLength(gbwt::Node::id(start_search_path.gbwt_search.first.node));
+        assert(start_search_path.end_offset <= node_length);
+
+        for (auto & end_search_paths_start_node: end_search_paths_start_nodes_index) {
+
+            auto path_it = find(start_search_path.path.begin(), start_search_path.path.end(), end_search_paths_start_node.first); 
+
+            while (path_it != start_search_path.path.end()) {
+
+                auto main_path_start_idx = path_it - start_search_path.path.begin();
+
+                for (auto end_alignment_idx: end_search_paths_start_node.second) {
+
+                    AlignmentSearchPath complete_paired_align_search_path = start_search_path;
+                    mergeAlignmentSearchPath(&complete_paired_align_search_path, main_path_start_idx, end_align_search_paths.at(end_alignment_idx));
+
+                    if (!complete_paired_align_search_path.gbwt_search.first.empty() && complete_paired_align_search_path.fragmentLength() <= max_pair_frag_length) {
+
+                        paired_align_search_paths->emplace_back(complete_paired_align_search_path);                         
                     }
                 }
 
                 ++path_it;
-                path_it = find(path_it, align_search_path.path.end(), start_nodes.first); 
+                path_it = find(path_it, start_search_path.path.end(), end_search_paths_start_node.first); 
             }
         }
+
+        paired_align_search_path_stack.emplace(start_search_path, false);
+
+        paired_align_search_path_stack.top().first.insert_length += (node_length - start_search_path.end_offset);
+        paired_align_search_path_stack.top().first.end_offset = node_length;
     }
 
     // Perform depth-first path extension.
-    while (!paired_align_search_path_queue.empty()) {
+    while (!paired_align_search_path_stack.empty()) {
 
-        AlignmentSearchPath * cur_paired_align_search_path = &(paired_align_search_path_queue.front());
-        assert(cur_paired_align_search_path->search_state.node != gbwt::ENDMARKER);
+        const pair<AlignmentSearchPath, bool> cur_paired_align_search_path = paired_align_search_path_stack.top();
+        paired_align_search_path_stack.pop();
+   
+        assert(!cur_paired_align_search_path.first.gbwt_search.first.empty());
+        assert(cur_paired_align_search_path.first.path.back() == cur_paired_align_search_path.first.gbwt_search.first.node);
 
-        auto end_alignment_start_nodes_index_itp = end_alignment_start_nodes_index.equal_range(cur_paired_align_search_path->search_state.node);
+        if (cur_paired_align_search_path.second) {
 
-        if (end_alignment_start_nodes_index_itp.first != end_alignment_start_nodes_index_itp.second) {
+            auto end_search_paths_start_nodes_index_it = end_search_paths_start_nodes_index.find(cur_paired_align_search_path.first.path.back());
 
-            while (end_alignment_start_nodes_index_itp.first != end_alignment_start_nodes_index_itp.second) {
+            if (end_search_paths_start_nodes_index_it != end_search_paths_start_nodes_index.end()) {
 
-                AlignmentSearchPath cur_paired_align_search_path_end = *cur_paired_align_search_path;
+                for (auto end_alignment_idx: end_search_paths_start_nodes_index_it->second) {
 
-                assert(cur_paired_align_search_path_end.path_end_pos == cur_paired_align_search_path_end.path.size());
-                --cur_paired_align_search_path_end.path_end_pos;
+                    AlignmentSearchPath complete_paired_align_search_path = cur_paired_align_search_path.first;
+                    complete_paired_align_search_path.insert_length -= complete_paired_align_search_path.end_offset;
 
-                auto complete_paired_align_search_paths = extendAlignmentPath(cur_paired_align_search_path_end, end_alignment, end_alignment_start_nodes_index_itp.first->second);
+                    complete_paired_align_search_path.end_offset = end_align_search_paths.at(end_alignment_idx).start_offset;
+                    complete_paired_align_search_path.insert_length += complete_paired_align_search_path.end_offset;
 
-                for (auto & complete_align_search_path: complete_paired_align_search_paths) {
+                    mergeAlignmentSearchPath(&complete_paired_align_search_path, cur_paired_align_search_path.first.path.size() - 1, end_align_search_paths.at(end_alignment_idx));
 
-                    if (!complete_align_search_path.search_state.empty() && complete_align_search_path.seq_length <= max_pair_seq_length) {
+                    if (!complete_paired_align_search_path.gbwt_search.first.empty() && complete_paired_align_search_path.fragmentLength() <= max_pair_frag_length) {
 
-                        paired_align_search_paths->emplace_back(complete_align_search_path);                         
+                        paired_align_search_paths->emplace_back(complete_paired_align_search_path);                         
                     }
                 }
+            }
+        }
 
-                ++end_alignment_start_nodes_index_itp.first;
+        if (!end_alignment_in_cycle) {
+
+            auto end_search_paths_nodes_it = end_search_paths_nodes.find(cur_paired_align_search_path.first.path.back());
+
+            if (end_search_paths_nodes_it != end_search_paths_nodes.end()) {
+
+                if (end_search_paths_nodes_it->second == num_unique_end_search_paths) {
+
+                    continue;  
+                }
             }
         }
            
-        if (cur_paired_align_search_path->seq_length + end_alignment.sequence().size() > max_pair_seq_length) {
+        if (cur_paired_align_search_path.first.fragmentLength() + end_alignment.sequence().size() - end_max_left_softclip_length > max_pair_frag_length) {
 
-            paired_align_search_path_queue.pop();
             continue;
         }
 
-        auto out_edges = paths_index.index().edges(cur_paired_align_search_path->search_state.node);
+        auto out_edges = paths_index.edges(cur_paired_align_search_path.first.gbwt_search.first.node);
 
         // End current extension if no outgoing edges exist.
         if (out_edges.empty()) {
 
-            paired_align_search_path_queue.pop();
             continue;
         }
 
         auto out_edges_it = out_edges.begin(); 
         assert(out_edges_it != out_edges.end());
         
-        ++out_edges_it;
-
         while (out_edges_it != out_edges.end()) {
 
-            if (out_edges_it->first != gbwt::ENDMARKER) {
+            if (out_edges_it->first != gbwt::ENDMARKER && out_edges_it->first != cur_paired_align_search_path.first.read_align_stats.back().internal_end_next_node) {
 
-                auto extended_path = paths_index.index().extend(cur_paired_align_search_path->search_state, out_edges_it->first);
+                auto extended_gbwt_search = cur_paired_align_search_path.first.gbwt_search;
+                paths_index.extend(&extended_gbwt_search, out_edges_it->first);
 
                 // Add new extension to queue if not empty (path found).
-                if (!extended_path.empty()) { 
+                if (!extended_gbwt_search.first.empty()) { 
 
-                    paired_align_search_path_queue.push(*cur_paired_align_search_path);
-                    paired_align_search_path_queue.back().path.emplace_back(extended_path.node);
-                    ++paired_align_search_path_queue.back().path_end_pos;
-                    paired_align_search_path_queue.back().seq_end_offset = paths_index.nodeLength(gbwt::Node::id(extended_path.node));
-                    paired_align_search_path_queue.back().search_state = extended_path;
-                    paired_align_search_path_queue.back().seq_length += paired_align_search_path_queue.back().seq_end_offset;
+                    paired_align_search_path_stack.emplace(cur_paired_align_search_path.first, true);
+
+                    paired_align_search_path_stack.top().first.path.emplace_back(extended_gbwt_search.first.node);
+                    paired_align_search_path_stack.top().first.gbwt_search = extended_gbwt_search;
+                    paired_align_search_path_stack.top().first.end_offset = paths_index.nodeLength(gbwt::Node::id(paired_align_search_path_stack.top().first.path.back()));
+                    paired_align_search_path_stack.top().first.insert_length += paired_align_search_path_stack.top().first.end_offset;
+                    paired_align_search_path_stack.top().first.read_align_stats.back().internal_end_next_node = gbwt::ENDMARKER;
                 }
             }
 
             ++out_edges_it;
         }
+    }
 
-        if (out_edges.begin()->first != gbwt::ENDMARKER) {
+    paired_align_search_paths->emplace_back(AlignmentSearchPath());
+
+    paired_align_search_paths->back().read_align_stats.emplace_back(AlignmentStats());
+    paired_align_search_paths->back().read_align_stats.back().score = Utils::doubleToInt((joint_start_align_score - joint_empty_start_align_score) / Utils::noise_score_log_base);
+
+    paired_align_search_paths->back().read_align_stats.emplace_back(AlignmentStats());
+    paired_align_search_paths->back().read_align_stats.back().score = Utils::doubleToInt((joint_end_align_score - joint_empty_end_align_score) / Utils::noise_score_log_base);
+}
+
+template<class AlignmentType>
+void AlignmentPathFinder<AlignmentType>::mergeAlignmentSearchPath(AlignmentSearchPath * main_align_search_path, uint32_t main_path_start_idx, const AlignmentSearchPath & second_align_search_path) const {
+
+    assert(!main_align_search_path->gbwt_search.first.empty());
+    assert(!second_align_search_path.gbwt_search.first.empty());
+
+    assert(main_align_search_path->isComplete());
+    assert(second_align_search_path.isComplete());
+
+    assert(main_path_start_idx < main_align_search_path->path.size());
+
+    assert(main_align_search_path->read_align_stats.size() == 1);
+    assert(second_align_search_path.read_align_stats.size() == 1);
+
+    assert(main_align_search_path->read_align_stats.back().maxInternalOffset() <= max_partial_offset);
+    assert(second_align_search_path.read_align_stats.back().maxInternalOffset() <= max_partial_offset);
+
+    if (second_align_search_path.path.size() < main_align_search_path->path.size() - main_path_start_idx) {
+
+        main_align_search_path->clear();
+        return;  
+    }
+
+    if (main_path_start_idx == 0) {
+
+        const int32_t main_read_left_offset = static_cast<int32_t>(main_align_search_path->start_offset) - static_cast<int32_t>(main_align_search_path->read_align_stats.back().clippedOffsetLeftBases());
+        const int32_t second_read_left_offset = static_cast<int32_t>(second_align_search_path.start_offset) - static_cast<int32_t>(second_align_search_path.read_align_stats.back().clippedOffsetLeftBases());
+
+        if (second_read_left_offset < main_read_left_offset) {
+                
+            main_align_search_path->clear();
+            return;    
+        } 
+    }
+
+    uint32_t second_path_start_idx = 0;
+
+    while (main_path_start_idx < main_align_search_path->path.size()) {
+
+        assert(second_path_start_idx < second_align_search_path.path.size());
+
+        if (main_align_search_path->path.at(main_path_start_idx) != second_align_search_path.path.at(second_path_start_idx)) {
+
+            main_align_search_path->clear();
+            return; 
+        }   
+
+        if (main_path_start_idx + 1 == main_align_search_path->path.size()) {
             
-            cur_paired_align_search_path->search_state = paths_index.index().extend(cur_paired_align_search_path->search_state, out_edges.begin()->first);
+            if (second_path_start_idx + 1 == second_align_search_path.path.size()) {
 
-            // End current extension if empty (no haplotypes found). 
-            if (cur_paired_align_search_path->search_state.empty()) { 
+                const uint32_t main_read_right_offset = main_align_search_path->end_offset + main_align_search_path->read_align_stats.back().clippedOffsetRightBases();
+                const uint32_t second_read_right_offset = second_align_search_path.end_offset + second_align_search_path.read_align_stats.back().clippedOffsetRightBases();
 
-                paired_align_search_path_queue.pop(); 
+                if (second_read_right_offset < main_read_right_offset) {
+                        
+                    main_align_search_path->clear();
+                    return;   
+                }
+
+                if (main_path_start_idx == 0) {
+
+                    assert(second_path_start_idx == 0);
+
+                    main_align_search_path->insert_length += (static_cast<int32_t>(max(main_align_search_path->start_offset, second_align_search_path.start_offset)) - static_cast<int32_t>(min(main_align_search_path->end_offset, second_align_search_path.end_offset)));             
+                
+                } else if (second_path_start_idx == 0) {
+
+                    main_align_search_path->insert_length += (static_cast<int32_t>(second_align_search_path.start_offset) - static_cast<int32_t>(min(main_align_search_path->end_offset, second_align_search_path.end_offset)));             
+
+                } else {
+
+                    main_align_search_path->insert_length -= min(main_align_search_path->end_offset, second_align_search_path.end_offset);
+                }
+
+            } else if (second_path_start_idx == 0) {
+
+                main_align_search_path->insert_length += (static_cast<int32_t>(second_align_search_path.start_offset) - static_cast<int32_t>(main_align_search_path->end_offset));             
+            
+            } else {
+
+                main_align_search_path->insert_length -= main_align_search_path->end_offset;
+            } 
+
+        } else if (second_path_start_idx == 0) {
+
+            assert(main_align_search_path->path.size() > 1);
+            assert(second_align_search_path.path.size() > 1);
+
+            const uint32_t node_length = paths_index.nodeLength(gbwt::Node::id(main_align_search_path->path.at(main_path_start_idx)));
+            assert(second_align_search_path.start_offset <= node_length);
+
+            if (main_path_start_idx == 0) {
+
+                assert(main_align_search_path->start_offset <= node_length);
+                main_align_search_path->insert_length -= (node_length - max(main_align_search_path->start_offset, second_align_search_path.start_offset));
 
             } else {
 
-                cur_paired_align_search_path->path.emplace_back(cur_paired_align_search_path->search_state.node);
-                ++cur_paired_align_search_path->path_end_pos;
-                cur_paired_align_search_path->seq_end_offset = paths_index.nodeLength(gbwt::Node::id(cur_paired_align_search_path->search_state.node));
-                cur_paired_align_search_path->seq_length += cur_paired_align_search_path->seq_end_offset;
+                main_align_search_path->insert_length -= (node_length - second_align_search_path.start_offset);             
             }
-    
+   
         } else {
 
-            paired_align_search_path_queue.pop();
+            main_align_search_path->insert_length -= paths_index.nodeLength(gbwt::Node::id(main_align_search_path->path.at(main_path_start_idx)));
+        } 
+
+        ++main_path_start_idx;
+        ++second_path_start_idx;
+    }
+
+    main_align_search_path->end_offset = second_align_search_path.end_offset;
+    main_align_search_path->read_align_stats.emplace_back(second_align_search_path.read_align_stats.front());
+    
+    assert(main_path_start_idx == main_align_search_path->path.size());
+    assert(second_path_start_idx <= second_align_search_path.path.size());
+
+    while (second_path_start_idx < second_align_search_path.path.size()) {
+
+        main_align_search_path->path.emplace_back(second_align_search_path.path.at(second_path_start_idx));
+        paths_index.extend(&(main_align_search_path->gbwt_search), main_align_search_path->path.back());
+
+        if (main_align_search_path->gbwt_search.first.empty()) {
+
+            break;            
         }
+
+        ++second_path_start_idx;
     }
 }
 
 template<class AlignmentType>
-multimap<gbwt::node_type, uint32_t> AlignmentPathFinder<AlignmentType>::getAlignmentStartNodesIndex(const vg::Alignment & alignment) const {
+vector<gbwt::node_type> AlignmentPathFinder<AlignmentType>::getAlignmentStartNodes(const vg::Alignment & alignment) const {
 
-    multimap<gbwt::node_type, uint32_t> alignment_start_nodes_index;
+    vector<gbwt::node_type> alignment_start_nodes;
 
     assert(alignment.path().mapping_size() > 0);
-    alignment_start_nodes_index.emplace(mapping_to_gbwt(alignment.path().mapping(0)), 0);
+    alignment_start_nodes.emplace_back(Utils::mapping_to_gbwt(alignment.path().mapping(0)));
 
-    return alignment_start_nodes_index;
+    return alignment_start_nodes;
 }
 
 template<class AlignmentType>
-multimap<gbwt::node_type, uint32_t> AlignmentPathFinder<AlignmentType>::getAlignmentStartNodesIndex(const vg::MultipathAlignment & alignment) const {
+vector<gbwt::node_type> AlignmentPathFinder<AlignmentType>::getAlignmentStartNodes(const vg::MultipathAlignment & alignment) const {
 
-    multimap<gbwt::node_type, uint32_t> alignment_start_nodes_index;
+    vector<gbwt::node_type> alignment_start_nodes;
 
     for (auto & start_idx: alignment.start()) {
 
         assert(alignment.subpath(start_idx).path().mapping_size() > 0);
-        alignment_start_nodes_index.emplace(mapping_to_gbwt(alignment.subpath(start_idx).path().mapping(0)), start_idx);
+        alignment_start_nodes.emplace_back(Utils::mapping_to_gbwt(alignment.subpath(start_idx).path().mapping(0)));
     }
 
-    return alignment_start_nodes_index;
+    return alignment_start_nodes;
+}
+
+template<class AlignmentType>
+vector<uint32_t> AlignmentPathFinder<AlignmentType>::getAlignmentStartSoftclipLengths(const vg::MultipathAlignment & alignment) const {
+
+    vector<uint32_t> start_softclip_lengths;
+    AlignmentStats read_align_stats;
+
+    for (auto & start_idx: alignment.start()) {
+
+        read_align_stats.updateLeftSoftclipLength(alignment.subpath(start_idx).path());
+        start_softclip_lengths.emplace_back(read_align_stats.left_softclip_length);
+    }
+
+    assert(!start_softclip_lengths.empty());
+    return start_softclip_lengths;
+}
+
+template<class AlignmentType>
+vector<uint32_t> AlignmentPathFinder<AlignmentType>::getAlignmentEndSoftclipLengths(const vg::MultipathAlignment & alignment) const {
+
+    vector<uint32_t> end_softclip_lengths;
+    AlignmentStats read_align_stats;
+
+    for (auto & subpath: alignment.subpath()) {
+
+        if (subpath.next_size() == 0) {
+
+            read_align_stats.updateRightSoftclipLength(subpath.path());
+            end_softclip_lengths.emplace_back(read_align_stats.right_softclip_length);
+        }
+    }
+
+    assert(!end_softclip_lengths.empty());
+    return end_softclip_lengths;
 }
 
 template<class AlignmentType>
@@ -536,6 +1217,29 @@ bool AlignmentPathFinder<AlignmentType>::isAlignmentDisconnected(const vg::Multi
     }
 
     return is_connected;
+}
+
+template<class AlignmentType>
+bool AlignmentPathFinder<AlignmentType>::filterAlignmentSearchPaths(const vector<AlignmentSearchPath> & align_search_paths, const vector<int32_t> & optimal_align_scores) const {
+
+    double max_min_optim_score_frac = 0;
+
+    for (auto & align_search_path: align_search_paths) {
+
+        if (align_search_path.isComplete()) {
+
+            max_min_optim_score_frac = max(max_min_optim_score_frac, align_search_path.minOptimalScoreFraction(optimal_align_scores));
+        }
+    }
+
+    if (max_min_optim_score_frac < min_best_score_filter) {
+
+        return true;
+    
+    } else {
+
+        return false;
+    }
 }
 
 template class AlignmentPathFinder<vg::Alignment>;

--- a/src/alignment_path_finder.hpp
+++ b/src/alignment_path_finder.hpp
@@ -17,8 +17,7 @@ class AlignmentPathFinder {
 
     public: 
     
-       	AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const uint32_t max_pair_seq_length_in);
-       	void setMaxPairSeqLength(const uint32_t max_pair_seq_length_in);
+       	AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const double min_best_score_filter_in);
 
 		vector<AlignmentPath> findAlignmentPaths(const AlignmentType & alignment) const;
 		vector<AlignmentPath> findPairedAlignmentPaths(const AlignmentType & alignment_1, const AlignmentType & alignment_2) const;
@@ -26,31 +25,67 @@ class AlignmentPathFinder {
 	private:
 
        	const PathsIndex & paths_index;
-
        	const string library_type;
-       	uint32_t max_pair_seq_length;
+
+       	const uint32_t max_pair_frag_length;
+       	const uint32_t max_partial_offset;
+       	const bool est_missing_noise_prob;
+
+       	const double min_best_score_filter;
 
 		bool alignmentHasPath(const vg::Alignment & alignment) const;
 		bool alignmentHasPath(const vg::MultipathAlignment & alignment) const;
 		
        	bool alignmentStartInGraph(const AlignmentType & alignment) const;
 
-		vector<AlignmentSearchPath> extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const;
-		vector<AlignmentSearchPath> extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment, const uint32_t subpath_start_idx) const;
-		void extendAlignmentPath(AlignmentSearchPath * align_search_path, const vg::Path & path) const;
+       	int32_t alignmentScore(const char & quality) const;
+		int32_t alignmentScore(const string & quality, const uint32_t & start_offset, const uint32_t & length) const;
 
-		vector<AlignmentSearchPath> extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment) const;
-		vector<AlignmentSearchPath> extendAlignmentPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment, const uint32_t subpath_start_idx) const;
-		void extendAlignmentPaths(vector<AlignmentSearchPath> * align_search_paths, const google::protobuf::RepeatedPtrField<vg::Subpath> & subpaths, const uint32_t subpath_start_idx) const;
+       	int32_t optimalAlignmentScore(const string & quality, const uint32_t seq_length) const;
+		int32_t optimalAlignmentScore(const vg::Alignment & alignment) const;
+		int32_t optimalAlignmentScore(const vg::MultipathAlignment & alignment) const;
 
-		void pairAlignmentPaths(vector<AlignmentSearchPath> * paired_align_search_paths, const AlignmentType & start_alignment, const AlignmentType & end_alignment) const;
+		vector<AlignmentSearchPath> extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const;
 
-		multimap<gbwt::node_type, uint32_t> getAlignmentStartNodesIndex(const vg::Alignment & alignment) const;
-		multimap<gbwt::node_type, uint32_t> getAlignmentStartNodesIndex(const vg::MultipathAlignment & alignment) const;
+		void extendAlignmentSearchPath(vector<AlignmentSearchPath> * align_search_paths, const vg::Path & path, const bool is_first_path, const bool is_last_path, const string & quality, const uint32_t seq_length, const bool add_internal_start) const;
+		void extendAlignmentSearchPath(AlignmentSearchPath * align_search_path, const vg::Mapping & mapping) const;
+
+		vector<AlignmentSearchPath> extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::MultipathAlignment & alignment) const;
+		void extendAlignmentSearchPaths(vector<AlignmentSearchPath> * align_search_paths, const AlignmentSearchPath & init_align_search_path, const google::protobuf::RepeatedPtrField<vg::Subpath> & subpaths, const uint32_t start_subpath_idx, const string & quality, const uint32_t seq_length, spp::sparse_hash_map<pair<uint32_t, uint32_t>, int32_t> * internal_node_subpaths, int32_t * best_align_score, const bool has_right_bonus) const;
+		
+		void findAlignmentSearchPaths(vector<AlignmentSearchPath> * align_search_paths, const AlignmentType & alignment) const;
+		void findPairedAlignmentSearchPaths(vector<AlignmentSearchPath> * paired_align_search_paths, const AlignmentType & start_alignment, const AlignmentType & end_alignment) const;
+
+		void mergeAlignmentSearchPath(AlignmentSearchPath * main_align_search_path, uint32_t main_path_start_idx, const AlignmentSearchPath & second_align_search_path) const;
+
+		vector<gbwt::node_type> getAlignmentStartNodes(const vg::Alignment & alignment) const;
+		vector<gbwt::node_type> getAlignmentStartNodes(const vg::MultipathAlignment & alignment) const;
+
+		vector<uint32_t> getAlignmentStartSoftclipLengths(const vg::MultipathAlignment & alignment) const;
+		vector<uint32_t> getAlignmentEndSoftclipLengths(const vg::MultipathAlignment & alignment) const;
 
 		bool isAlignmentDisconnected(const vg::Alignment & alignment) const;
 		bool isAlignmentDisconnected(const vg::MultipathAlignment & alignment) const;
+
+		bool filterAlignmentSearchPaths(const vector<AlignmentSearchPath> & align_search_paths, const vector<int32_t> & optimal_align_scores) const;
 };
+
+namespace std {
+
+    template<> 
+    struct hash<pair<uint32_t, uint32_t> >
+    {
+        size_t operator()(const pair<uint32_t, uint32_t> & values) const
+        {
+            size_t seed = 0;
+            
+            spp::hash_combine(seed, values.first);
+            spp::hash_combine(seed, values.second);
+
+            return seed;
+        }
+    };
+}
 
 
 #endif

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -171,7 +171,7 @@ double FragmentLengthDist::logProb(const uint32_t value) const {
     
     } else {
 
-        return log_normal_pdf<double>(value, mean_, sd_);
+        return Utils::log_normal_pdf<double>(value, mean_, sd_);
     }
 }
 
@@ -191,7 +191,7 @@ void FragmentLengthDist::setLogProbBuffer(const uint32_t size) {
 
     for (size_t i = 0; i < size; ++i) {
 
-        log_prob_buffer.at(i) = log_normal_pdf<double>(i, mean_, sd_);
+        log_prob_buffer.at(i) = Utils::log_normal_pdf<double>(i, mean_, sd_);
     }
 }
 

--- a/src/io/register_libvg_io.cpp
+++ b/src/io/register_libvg_io.cpp
@@ -6,6 +6,7 @@
 // Keep these includes in alphabetical order.
 
 #include "register_loader_saver_gbwt.hpp"
+#include "register_loader_saver_r_index.hpp"
 #include "register_loader_saver_xg.hpp"
 
 #include "register_libvg_io.hpp"
@@ -19,6 +20,7 @@ using namespace std;
 
 bool register_libvg_io() {
     register_loader_saver_gbwt();
+    register_loader_saver_r_index();
     register_loader_saver_xg();
     return true;
 }

--- a/src/io/register_loader_saver_r_index.cpp
+++ b/src/io/register_loader_saver_r_index.cpp
@@ -1,0 +1,39 @@
+/**
+ * \file register_loader_saver_r_index.cpp
+ * Defines IO for an r-index from stream files.
+ */
+
+#include "vg/io/registry.hpp"
+#include "register_loader_saver_r_index.hpp"
+
+#include "gbwt/fast_locate.h"
+
+namespace vg {
+
+namespace io {
+
+using namespace std;
+using namespace vg::io;
+
+void register_loader_saver_r_index() {
+
+    Registry::register_bare_loader_saver<gbwt::FastLocate>("R-INDEX", [](istream& input) -> void* {
+        // Allocate an r-index
+        gbwt::FastLocate* index = new gbwt::FastLocate();
+
+        // Load it
+        index->load(input);
+
+        // Return it so the caller owns it.
+        return (void*) index;
+    }, [](const void* index_void, ostream& output) {
+        // Cast to r-index and serialize to the stream.
+        assert(index_void != nullptr);
+        ((const gbwt::FastLocate*) index_void)->serialize(output);
+    });
+}
+
+}
+
+}
+

--- a/src/io/register_loader_saver_r_index.hpp
+++ b/src/io/register_loader_saver_r_index.hpp
@@ -1,0 +1,21 @@
+#ifndef VG_IO_REGISTER_LOADER_SAVER_R_INDEX_HPP_INCLUDED
+#define VG_IO_REGISTER_LOADER_SAVER_R_INDEX_HPP_INCLUDED
+
+/**
+ * \file register_loader_saver_r_index.hpp
+ * Defines IO for an r-index from stream files.
+ */
+ 
+namespace vg {
+
+namespace io {
+
+using namespace std;
+
+void register_loader_saver_r_index();
+
+}
+
+}
+
+#endif

--- a/src/path_abundance_estimator.hpp
+++ b/src/path_abundance_estimator.hpp
@@ -33,8 +33,8 @@ class PathAbundanceEstimator : public PathEstimator {
         const uint32_t num_gibbs_samples;
         const uint32_t gibbs_thin_its;
 
-        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::RowVectorXui & read_counts) const;
-        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const;
+        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts) const;
+        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const;
         void removeNoiseAndRenormalizeAbundances(PathClusterEstimates * path_cluster_estimates) const;    
         void updateEstimates(PathClusterEstimates * path_cluster_estimates, const PathClusterEstimates & new_path_cluster_estimates, const vector<uint32_t> & path_indices, const uint32_t sample_count) const;
 };
@@ -48,7 +48,7 @@ class MinimumPathAbundanceEstimator : public PathAbundanceEstimator {
 
         void estimate(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng);
 
-        vector<uint32_t> weightedMinimumPathCover(const Eigen::ColMatrixXb & read_path_cover, const Eigen::RowVectorXui & read_counts, const Eigen::RowVectorXd & path_weights) const;
+        vector<uint32_t> weightedMinimumPathCover(const Utils::ColMatrixXb & read_path_cover, const Utils::RowVectorXui & read_counts, const Utils::RowVectorXd & path_weights) const;
 };
 
 class NestedPathAbundanceEstimator : public PathAbundanceEstimator {
@@ -69,7 +69,7 @@ class NestedPathAbundanceEstimator : public PathAbundanceEstimator {
         const bool use_group_post_gibbs;
 
         void inferAbundancesIndependentGroups(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng) const;        
-        void inferAbundancesCollapsedGroups(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng) const;        
+        void inferAbundancesCollapsedGroups(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng);        
 
         vector<vector<uint32_t> > findPathGroups(const vector<PathInfo> & paths) const;
         pair<vector<vector<uint32_t> >, vector<uint32_t> > findPathSourceGroups(const vector<PathInfo> & paths) const;

--- a/src/path_clusters.hpp
+++ b/src/path_clusters.hpp
@@ -16,7 +16,7 @@ class PathClusters {
 
     public: 
 
-        PathClusters(const uint32_t num_threads_in, const PathsIndex & paths_index, const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index, spp::sparse_hash_map<gbwt::SearchState, uint32_t> * search_to_path_index);
+        PathClusters(const uint32_t num_threads_in, const PathsIndex & paths_index, const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index);
 
         void addNodeClusters(const PathsIndex & paths_index);
 
@@ -31,23 +31,6 @@ class PathClusters {
     	void createPathClusters(const vector<spp::sparse_hash_set<uint32_t> > & connected_paths);
         void mergeClusters(const vector<spp::sparse_hash_set<uint32_t> > & connected_clusters);
 };
-
-namespace std {
-
-    template<> 
-    struct hash<gbwt::SearchState>
-    {
-        size_t operator()(gbwt::SearchState const & search_state) const
-        {
-            size_t seed = 0;
-            spp::hash_combine(seed, search_state.node);
-            spp::hash_combine(seed, search_state.range.first);
-            spp::hash_combine(seed, search_state.range.second);
-
-            return seed;
-        }
-    };
-}
 
 
 #endif

--- a/src/path_estimator.cpp
+++ b/src/path_estimator.cpp
@@ -12,13 +12,13 @@ static const double burn_it_scaling = 0.025;
 static const uint32_t min_gibbs_it = 100; 
 static const double gibbs_it_scaling = 0.05; 
 
-bool probabilityCountRowSorter(const pair<Eigen::RowVectorXd, uint32_t> & lhs, const pair<Eigen::RowVectorXd, uint32_t> & rhs) { 
+bool probabilityCountRowSorter(const pair<Utils::RowVectorXd, uint32_t> & lhs, const pair<Utils::RowVectorXd, uint32_t> & rhs) { 
 
     assert(lhs.first.cols() == rhs.first.cols());
 
     for (size_t i = 0; i < lhs.first.cols(); ++i) {
 
-        if (!doubleCompare(lhs.first(i), rhs.first(i))) {
+        if (!Utils::doubleCompare(lhs.first(i), rhs.first(i))) {
 
             return (lhs.first(i) < rhs.first(i));    
         }         
@@ -32,13 +32,13 @@ bool probabilityCountRowSorter(const pair<Eigen::RowVectorXd, uint32_t> & lhs, c
     return false;
 }
 
-bool probabilityCountColSorter(const pair<Eigen::ColVectorXd, uint32_t> & lhs, const pair<Eigen::ColVectorXd, uint32_t> & rhs) { 
+bool probabilityCountColSorter(const pair<Utils::ColVectorXd, uint32_t> & lhs, const pair<Utils::ColVectorXd, uint32_t> & rhs) { 
 
     assert(lhs.first.rows() == rhs.first.rows());
 
     for (size_t i = 0; i < lhs.first.rows(); ++i) {
 
-        if (!doubleCompare(lhs.first(i), rhs.first(i))) {
+        if (!Utils::doubleCompare(lhs.first(i), rhs.first(i))) {
 
             return (lhs.first(i) < rhs.first(i));    
         }         
@@ -54,28 +54,31 @@ bool probabilityCountColSorter(const pair<Eigen::ColVectorXd, uint32_t> & lhs, c
 
 PathEstimator::PathEstimator(const double prob_precision_in) : prob_precision(prob_precision_in) {}
 
-void PathEstimator::constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const {
+void PathEstimator::constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const {
 
     assert(!cluster_probs.empty());
 
-    *read_path_probs = Eigen::ColMatrixXd::Zero(cluster_probs.size(), num_paths);
-    *noise_probs = Eigen::ColVectorXd(cluster_probs.size());
-    *read_counts = Eigen::RowVectorXui(cluster_probs.size());
+    *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), num_paths);
+    *noise_probs = Utils::ColVectorXd(cluster_probs.size());
+    *read_counts = Utils::RowVectorXui(cluster_probs.size());
 
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
-        for (auto & prob: cluster_probs.at(i).probabilities()) {
+        for (auto & path_probs: cluster_probs.at(i).pathProbs()) {
 
-            assert(prob.first < num_paths);
-            (*read_path_probs)(i, prob.first) = prob.second;
+            for (auto & path: path_probs.second) {
+
+                assert(path < num_paths);
+                (*read_path_probs)(i, path) = path_probs.first;
+            }
         }
 
-        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProbability();
+        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProb();
         (*read_counts)(0, i) = cluster_probs.at(i).readCount();
     }
 }
 
-void PathEstimator::constructPartialProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const {
+void PathEstimator::constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const {
 
     assert(!cluster_probs.empty());
     assert(!path_ids.empty());
@@ -87,28 +90,31 @@ void PathEstimator::constructPartialProbabilityMatrix(Eigen::ColMatrixXd * read_
         path_id_idx.at(path_ids.at(i)) = i;
     }
 
-    *read_path_probs = Eigen::ColMatrixXd::Zero(cluster_probs.size(), path_ids.size());
-    *noise_probs = Eigen::ColVectorXd(cluster_probs.size());
-    *read_counts = Eigen::RowVectorXui(cluster_probs.size());
+    *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), path_ids.size());
+    *noise_probs = Utils::ColVectorXd(cluster_probs.size());
+    *read_counts = Utils::RowVectorXui(cluster_probs.size());
 
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
-        for (auto & prob: cluster_probs.at(i).probabilities()) {
+        for (auto & path_probs: cluster_probs.at(i).pathProbs()) {
 
-            assert(prob.first < num_paths);
+            for (auto & path: path_probs.second) {
+    
+                assert(path < num_paths);
 
-            if (path_id_idx.at(prob.first) >= 0) {
+                if (path_id_idx.at(path) >= 0) {
 
-                (*read_path_probs)(i, path_id_idx.at(prob.first)) = prob.second;
+                    (*read_path_probs)(i, path_id_idx.at(path)) = path_probs.first;
+                }
             }
         }
 
-        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProbability();
+        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProb();
         (*read_counts)(0, i) = cluster_probs.at(i).readCount();
     }
 }
 
-void PathEstimator::constructGroupedProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const {
+void PathEstimator::constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const {
 
     assert(!cluster_probs.empty());
     assert(!path_groups.empty());
@@ -125,28 +131,31 @@ void PathEstimator::constructGroupedProbabilityMatrix(Eigen::ColMatrixXd * read_
         }
     }
 
-    *read_path_probs = Eigen::ColMatrixXd::Zero(cluster_probs.size(), path_groups.size());
-    *noise_probs = Eigen::ColVectorXd(cluster_probs.size());
-    *read_counts = Eigen::RowVectorXui(cluster_probs.size());
+    *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), path_groups.size());
+    *noise_probs = Utils::ColVectorXd(cluster_probs.size());
+    *read_counts = Utils::RowVectorXui(cluster_probs.size());
 
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
-        for (auto & prob: cluster_probs.at(i).probabilities()) {
+        for (auto & path_probs: cluster_probs.at(i).pathProbs()) {
 
-            assert(prob.first < num_paths);
+            for (auto & path: path_probs.second) {
 
-            for (auto & group_id: path_id_group_idx.at(prob.first)) {
+                assert(path < num_paths);
 
-                (*read_path_probs)(i, group_id) += prob.second;
+                for (auto & group_id: path_id_group_idx.at(path)) {
+
+                    (*read_path_probs)(i, group_id) += path_probs.first;
+                }
             }
         }
 
-        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProbability();
+        (*noise_probs)(i, 0) = cluster_probs.at(i).noiseProb();
         (*read_counts)(0, i) = cluster_probs.at(i).readCount();
     }
 }
 
-void PathEstimator::addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, const Eigen::ColVectorXd & noise_probs) const {
+void PathEstimator::addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, const Utils::ColVectorXd & noise_probs) const {
 
     assert(read_path_probs->rows() == noise_probs.rows());
 
@@ -158,12 +167,12 @@ void PathEstimator::addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * r
     read_path_probs->col(read_path_probs->cols() - 1) = noise_probs;
 }
 
-void PathEstimator::rowSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) const {
+void PathEstimator::rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const {
 
     assert(read_path_probs->rows() > 0);
     assert(read_path_probs->rows() == read_counts->cols());
 
-    vector<pair<Eigen::RowVectorXd, uint32_t> > read_path_prob_rows;
+    vector<pair<Utils::RowVectorXd, uint32_t> > read_path_prob_rows;
     read_path_prob_rows.reserve(read_path_probs->rows());
 
     for (size_t i = 0; i < read_path_probs->rows(); ++i) {
@@ -180,7 +189,7 @@ void PathEstimator::rowSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_prob
     }    
 }
 
-void PathEstimator::readCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) const {
+void PathEstimator::readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const {
 
     assert(read_path_probs->rows() > 0);
     assert(read_path_probs->rows() == read_counts->cols());
@@ -222,11 +231,11 @@ void PathEstimator::readCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path
     read_counts->conservativeResize(read_counts->rows(), prev_unique_probs_row + 1);
 }
 
-void PathEstimator::colSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs) const {
+void PathEstimator::colSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const {
 
     assert(read_path_probs->cols() > 0);
 
-    vector<pair<Eigen::ColVectorXd, uint32_t> > read_path_prob_cols;
+    vector<pair<Utils::ColVectorXd, uint32_t> > read_path_prob_cols;
     read_path_prob_cols.reserve(read_path_probs->cols());
 
     for (size_t i = 0; i < read_path_probs->cols(); ++i) {
@@ -242,7 +251,7 @@ void PathEstimator::colSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_prob
     }    
 }
 
-void PathEstimator::pathCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs) const {
+void PathEstimator::pathCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const {
 
     assert(read_path_probs->cols() > 0);    
     colSortProbabilityMatrix(read_path_probs);
@@ -293,7 +302,7 @@ vector<double> PathEstimator::calcPathLogFrequences(const vector<uint32_t> & pat
     return path_log_freqs;
 }
 
-void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
+void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -315,7 +324,7 @@ void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path
 
         assert(path_cluster_estimates->path_group_sets.at(i).size() == group_size);
 
-        Eigen::ColVectorXd group_read_probs = noise_probs;
+        Utils::ColVectorXd group_read_probs = noise_probs;
 
         for (auto & path_idx: path_cluster_estimates->path_group_sets.at(i)) {
 
@@ -329,9 +338,9 @@ void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path
             path_cluster_estimates->posteriors(0, i) += path_log_freqs.at(path_idx);
         }
 
-        path_cluster_estimates->posteriors(0, i) += log(numPermutations(path_cluster_estimates->path_group_sets.at(i)));
+        path_cluster_estimates->posteriors(0, i) += log(Utils::numPermutations(path_cluster_estimates->path_group_sets.at(i)));
 
-        sum_log_posterior = add_log(sum_log_posterior, path_cluster_estimates->posteriors(0, i));
+        sum_log_posterior = Utils::add_log(sum_log_posterior, path_cluster_estimates->posteriors(0, i));
     }
 
     for (size_t i = 0; i < path_cluster_estimates->posteriors.cols(); ++i) {
@@ -340,7 +349,7 @@ void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path
     }
 }
 
-void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
+void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -375,7 +384,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
 
     sort(marginal_posteriors.rbegin(), marginal_posteriors.rend());
 
-    const Eigen::ColVectorXd max_read_probs = read_path_probs.rowwise().maxCoeff();
+    const Utils::ColVectorXd max_read_probs = read_path_probs.rowwise().maxCoeff();
 
     vector<double> log_likelihoods;
 
@@ -386,7 +395,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
 
         const uint32_t first_path_idx = marginal_posteriors.at(i).second;
 
-        Eigen::ColVectorXd group_read_probs_base = noise_probs;
+        Utils::ColVectorXd group_read_probs_base = noise_probs;
         group_read_probs_base += read_path_probs.col(first_path_idx);
 
         double max_log_likelihood_best = read_counts.cast<double>() * (group_read_probs_base + max_read_probs).array().log().matrix();
@@ -402,7 +411,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
             const uint32_t second_path_idx = marginal_posteriors.at(j).second;
 
             log_likelihoods.emplace_back(read_counts.cast<double>() * (group_read_probs_base + read_path_probs.col(second_path_idx)).array().log().matrix());
-            log_likelihoods.back() += path_log_freqs.at(first_path_idx) + path_log_freqs.at(second_path_idx) + log(numPermutations(vector<uint32_t>({first_path_idx, second_path_idx})));
+            log_likelihoods.back() += path_log_freqs.at(first_path_idx) + path_log_freqs.at(second_path_idx) + log(Utils::numPermutations(vector<uint32_t>({first_path_idx, second_path_idx})));
 
             if (log_likelihoods.back() - max_log_likelihood < max_log_likelihood_diff) {
 
@@ -411,14 +420,14 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
             }
 
             max_log_likelihood = max(max_log_likelihood, log_likelihoods.back());
-            sum_log_posterior = add_log(sum_log_posterior, log_likelihoods.back());
+            sum_log_posterior = Utils::add_log(sum_log_posterior, log_likelihoods.back());
 
             path_cluster_estimates->path_group_sets.emplace_back(vector<uint32_t>({first_path_idx, second_path_idx}));
         }
     }
 
     assert(log_likelihoods.size() == path_cluster_estimates->path_group_sets.size());
-    path_cluster_estimates->posteriors = Eigen::RowVectorXd(1, log_likelihoods.size());
+    path_cluster_estimates->posteriors = Utils::RowVectorXd(1, log_likelihoods.size());
 
     for (size_t i = 0; i < path_cluster_estimates->posteriors.cols(); ++i) {
 
@@ -426,7 +435,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
     }
 }
 
-void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const {
+void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -478,7 +487,7 @@ void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path
 
                 if (group_path_sampler_cache_it.second) {
 
-                    Eigen::ColVectorXd group_read_probs = noise_probs;
+                    Utils::ColVectorXd group_read_probs = noise_probs;
 
                     for (uint32_t k = 0; k < group_size; ++k) {
 
@@ -498,7 +507,7 @@ void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path
                         group_probs.emplace_back(read_counts.cast<double>() * (group_read_probs + read_path_probs.col(k)).array().log().matrix());
                         group_probs.back() += path_log_freqs.at(k);
 
-                        sum_log_group_probs = add_log(sum_log_group_probs, group_probs.back());
+                        sum_log_group_probs = Utils::add_log(sum_log_group_probs, group_probs.back());
                     }
 
                     for (auto & prob: group_probs) {
@@ -532,7 +541,7 @@ void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path
         }
     }
 
-    path_cluster_estimates->posteriors = Eigen::RowVectorXd(1, path_group_sample_counts.size());
+    path_cluster_estimates->posteriors = Utils::RowVectorXd(1, path_group_sample_counts.size());
 
     for (size_t i = 0; i < path_cluster_estimates->posteriors.cols(); ++i) {
 

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -26,23 +26,23 @@ class PathEstimator {
        
         const double prob_precision;
 
-        void constructProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
-        void constructPartialProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const;
-        void constructGroupedProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::ColVectorXd * noise_probs, Eigen::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
+        void constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
+        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const;
+        void constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
 
-        void addNoiseAndNormalizeProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, const Eigen::ColVectorXd & noise_probs) const;
+        void addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, const Utils::ColVectorXd & noise_probs) const;
 
-        void readCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) const;
-        void pathCollapseProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs) const;
+        void readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const;
+        void pathCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const;
 
-        void calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
-        void calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
-        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Eigen::ColMatrixXd & read_path_probs, const Eigen::ColVectorXd & noise_probs, const Eigen::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const;
+        void calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
+        void calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
+        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const;
 
     private:
 
-        void rowSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs, Eigen::RowVectorXui * read_counts) const;
-        void colSortProbabilityMatrix(Eigen::ColMatrixXd * read_path_probs) const;
+        void rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const;
+        void colSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const;
 
         vector<double> calcPathLogFrequences(const vector<uint32_t> & path_counts) const;
 };

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -8,9 +8,9 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
 
     if (!cluster_probs.empty()) {
 
-        Eigen::ColMatrixXd read_path_probs;
-        Eigen::ColVectorXd noise_probs;
-        Eigen::RowVectorXui read_counts;
+        Utils::ColMatrixXd read_path_probs;
+        Utils::ColVectorXd noise_probs;
+        Utils::RowVectorXui read_counts;
 
         constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_cluster_estimates->paths.size());
 
@@ -40,9 +40,9 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
 
     if (!cluster_probs.empty()) {
 
-        Eigen::ColMatrixXd read_path_probs;
-        Eigen::ColVectorXd noise_probs;
-        Eigen::RowVectorXui read_counts;
+        Utils::ColMatrixXd read_path_probs;
+        Utils::ColVectorXd noise_probs;
+        Utils::RowVectorXui read_counts;
 
         constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_cluster_estimates->paths.size());
 

--- a/src/paths_index.hpp
+++ b/src/paths_index.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "gbwt/gbwt.h"
+#include "gbwt/fast_locate.h"
 #include "handlegraph/handle_graph.hpp"
 #include "vg/io/basic_stream.hpp"
 #include "fragment_length_dist.hpp"
@@ -17,16 +18,21 @@ class PathsIndex {
 
     public: 
     	
-        PathsIndex(const gbwt::GBWT & gbwt_index, const vg::Graph & graph);
-        PathsIndex(const gbwt::GBWT & gbwt_index, const handlegraph::HandleGraph & graph);
-
-        const gbwt::GBWT & index() const;
+        PathsIndex(const gbwt::GBWT & gbwt_index_in, const gbwt::FastLocate & r_index_in, const vg::Graph & graph);
+        PathsIndex(const gbwt::GBWT & gbwt_index_in, const gbwt::FastLocate & r_index_in, const handlegraph::HandleGraph & graph);
 
         uint32_t numberOfNodes() const;
         bool hasNodeId(const uint32_t node_id) const;
         uint32_t nodeLength(const uint32_t node_id) const;
 
-        vector<gbwt::size_type> locatePathIds(const gbwt::SearchState & search) const;
+        vector<gbwt::edge_type> edges(const gbwt::node_type gbwt_node) const;
+
+        bool bidirectional() const;
+        uint32_t numberOfPaths() const;
+
+        void find(pair<gbwt::SearchState, gbwt::size_type> * gbwt_search, const gbwt::node_type gbwt_node) const;
+        void extend(pair<gbwt::SearchState, gbwt::size_type> * gbwt_search, const gbwt::node_type gbwt_node) const;
+        vector<gbwt::size_type> locatePathIds(const pair<gbwt::SearchState, gbwt::size_type> & gbwt_search) const;
 
         string pathName(const uint32_t path_id) const;
         uint32_t pathLength(uint32_t path_id) const;
@@ -34,7 +40,9 @@ class PathsIndex {
 
     private:
 
-        const gbwt::GBWT & index_;
+        const gbwt::GBWT & gbwt_index;
+        const gbwt::FastLocate & r_index;
+
         vector<int32_t> node_lengths;
 
         double calculateLowerPhi(const double value) const;

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -7,7 +7,6 @@
 #include <limits>
 #include <sstream>
 
-static const double score_log_base = 1.383325268738;
 
 ReadPathProbabilities::ReadPathProbabilities() {
 
@@ -27,14 +26,14 @@ uint32_t ReadPathProbabilities::readCount() const {
     return read_count;
 }
 
-double ReadPathProbabilities::noiseProbability() const {
+double ReadPathProbabilities::noiseProb() const {
 
     return noise_prob;
 }
 
-const vector<pair<uint32_t, double> > & ReadPathProbabilities::probabilities() const {
+const vector<pair<double, vector<uint32_t> > >& ReadPathProbabilities::pathProbs() const {
 
-    return read_path_probs;
+    return path_probs;
 }
 
 void ReadPathProbabilities::addReadCount(const uint32_t multiplicity_in) {
@@ -42,35 +41,53 @@ void ReadPathProbabilities::addReadCount(const uint32_t multiplicity_in) {
     read_count += multiplicity_in;
 }
 
-void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end) {
+void ReadPathProbabilities::calcAlignPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob) {
 
-    assert(!align_paths.empty());
+    assert(align_paths.size() > 1);
     assert(align_paths.size() == align_paths_ids.size());
-
     assert(clustered_path_index.size() == cluster_paths.size());
+
+    assert(path_probs.empty());
 
     if (align_paths.front().min_mapq > 0) {
 
-        noise_prob = phred_to_prob(align_paths.front().min_mapq);
+        noise_prob = max(prob_precision, max(min_noise_prob, Utils::phred_to_prob(align_paths.front().min_mapq)));
         assert(noise_prob < 1 && noise_prob > 0);
 
-        vector<double> align_paths_log_probs;
-        align_paths_log_probs.reserve(align_paths.size());
+        assert(align_paths.back().gbwt_search.first.empty());
+        assert(align_paths_ids.back().empty());
+        assert(align_paths.back().score_sum <= 0);
 
-        for (auto & align_path: align_paths) {
+        noise_prob += (1 - noise_prob) * exp(align_paths.back().score_sum * Utils::noise_score_log_base);
+
+        if (align_paths.back().score_sum == 0) {
+
+            assert(Utils::doubleCompare(noise_prob, 1));
+            return;
+        }
+
+        vector<double> align_paths_log_probs;
+        align_paths_log_probs.reserve(align_paths.size() - 1);
+
+        for (size_t i = 0; i < align_paths.size() - 1; ++i) {
+
+            const AlignmentPath & align_path = align_paths.at(i);
 
             assert(align_paths.front().min_mapq == align_path.min_mapq);
-            align_paths_log_probs.emplace_back(score_log_base * align_path.score_sum);
+            align_paths_log_probs.emplace_back(align_path.score_sum * Utils::score_log_base);
 
             if (!is_single_end) {
 
-                align_paths_log_probs.back() += fragment_length_dist.logProb(align_path.seq_length);
+                align_paths_log_probs.back() += fragment_length_dist.logProb(align_path.frag_length);
             }
         }
         
+        assert(align_paths_ids.size() == align_paths_log_probs.size() + 1);
         vector<double> read_path_log_probs(clustered_path_index.size(), numeric_limits<double>::lowest());
 
-        for (size_t i = 0; i < align_paths.size(); ++i) {
+        for (size_t i = 0; i < align_paths_ids.size() - 1; ++i) {
+
+            assert(!align_paths_ids.at(i).empty());
 
             for (auto path_id: align_paths_ids.at(i)) {
 
@@ -79,14 +96,14 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
 
                 uint32_t path_idx = clustered_path_index_it->second;
 
-                if (doubleCompare(cluster_paths.at(path_idx).effective_length, 0)) {
+                if (Utils::doubleCompare(cluster_paths.at(path_idx).effective_length, 0)) {
 
-                    assert(doubleCompare(read_path_log_probs.at(path_idx), numeric_limits<double>::lowest()));
+                    assert(Utils::doubleCompare(read_path_log_probs.at(path_idx), numeric_limits<double>::lowest()));
                     read_path_log_probs.at(path_idx) = numeric_limits<double>::lowest();
 
                 } else {
 
-                    // account for really rare cases when a mpmap alignment can have multiple alignments on the same path
+                    // account for rare cases when a mpmap alignment can have multiple alignments on the same path
                     read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), align_paths_log_probs.at(i) - log(cluster_paths.at(path_idx).effective_length));
                 }
             }
@@ -96,7 +113,7 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
 
         for (auto & log_prob: read_path_log_probs) {
 
-            read_path_log_probs_sum = add_log(read_path_log_probs_sum, log_prob);
+            read_path_log_probs_sum = Utils::add_log(read_path_log_probs_sum, log_prob);
         }
 
         assert(read_path_log_probs_sum > numeric_limits<double>::lowest());
@@ -108,34 +125,57 @@ void ReadPathProbabilities::calcReadPathProbabilities(const vector<AlignmentPath
 
             if (read_path_log_probs.at(i) >= prob_precision) {
 
-                read_path_probs.emplace_back(i, read_path_log_probs.at(i));
+                auto path_probs_it = path_probs.begin();
+
+                while (path_probs_it != path_probs.end()) {
+
+                    if (abs(path_probs_it->first - read_path_log_probs.at(i)) < prob_precision) {
+
+                        path_probs_it->first = ((path_probs_it->first * path_probs_it->second.size() + read_path_log_probs.at(i)) / (path_probs_it->second.size() + 1));
+                        path_probs_it->second.emplace_back(i);
+
+                        break;
+                    }
+                    
+                    ++path_probs_it;
+                }
+
+                if (path_probs_it == path_probs.end()) {
+
+                    path_probs.emplace_back(read_path_log_probs.at(i), vector<uint32_t>({static_cast<uint32_t>(i)}));
+                }
             }
         }
-    }
 
-    sort(read_path_probs.begin(), read_path_probs.end());
+        sort(path_probs.begin(), path_probs.end());
+
+        if (path_probs.empty()) {
+
+            noise_prob = 1;
+        }
+    }
 }
 
-bool ReadPathProbabilities::mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2) {
+bool ReadPathProbabilities::quickMergeIdentical(const ReadPathProbabilities & probs_2) {
 
-    if (probabilities().size() != probs_2.probabilities().size()) {
+    if (pathProbs().size() != probs_2.pathProbs().size()) {
 
         return false;
     }
 
-    if (abs(noise_prob - probs_2.noiseProbability()) < prob_precision) {
+    if (abs(noise_prob - probs_2.noiseProb()) < prob_precision) {
 
-        for (size_t i = 0; i < read_path_probs.size(); ++i) {
+        for (size_t i = 0; i < pathProbs().size(); ++i) {
 
-            if (read_path_probs.at(i).first != probs_2.probabilities().at(i).first) {
-
-                return false;
-            }  
-
-            if (abs(read_path_probs.at(i).second - probs_2.probabilities().at(i).second) >= prob_precision) {
+            if (abs(pathProbs().at(i).first - probs_2.pathProbs().at(i).first) >= prob_precision) {
 
                 return false;
             }
+
+            if (pathProbs().at(i).second != probs_2.pathProbs().at(i).second) {
+
+                return false;
+            }  
         }
 
         addReadCount(probs_2.readCount());
@@ -145,52 +185,23 @@ bool ReadPathProbabilities::mergeIdenticalReadPathProbabilities(const ReadPathPr
     return false;
 }
 
-vector<pair<double, vector<uint32_t> > > ReadPathProbabilities::collapsedProbabilities() const {
-
-    vector<pair<double, vector<uint32_t> > > collapsed_probs;
-
-    for (auto & prob: read_path_probs) {
-
-        auto collapsed_probs_it = collapsed_probs.begin();
-
-        while (collapsed_probs_it != collapsed_probs.end()) {
-
-            if (abs(collapsed_probs_it->first - prob.second) < prob_precision) {
-
-                collapsed_probs_it->second.emplace_back(prob.first);
-                break;
-            }
-            
-            ++collapsed_probs_it;
-        }
-
-        if (collapsed_probs_it == collapsed_probs.end()) {
-
-            collapsed_probs.emplace_back(prob.second, vector<uint32_t>(1, prob.first));
-        }
-    }
-
-    sort(collapsed_probs.begin(), collapsed_probs.end());
-    return collapsed_probs;
-}
-
 bool operator==(const ReadPathProbabilities & lhs, const ReadPathProbabilities & rhs) { 
 
-    if (lhs.readCount() == rhs.readCount() && doubleCompare(lhs.noiseProbability(), rhs.noiseProbability())) {
+    if (lhs.readCount() == rhs.readCount() && Utils::doubleCompare(lhs.noiseProb(), rhs.noiseProb())) {
 
-        if (lhs.probabilities().size() == rhs.probabilities().size()) {
+        if (lhs.pathProbs().size() == rhs.pathProbs().size()) {
 
-            for (size_t i = 0; i < lhs.probabilities().size(); ++i) {
+            for (size_t i = 0; i < lhs.pathProbs().size(); ++i) {
 
-                if (lhs.probabilities().at(i).first != rhs.probabilities().at(i).first) {
-
-                    return false;
-                }  
-
-                if (!doubleCompare(lhs.probabilities().at(i).second, rhs.probabilities().at(i).second)) {
+                if (!Utils::doubleCompare(lhs.pathProbs().at(i).first, rhs.pathProbs().at(i).first)) {
 
                     return false;
                 }
+
+                if (lhs.pathProbs().at(i).second != rhs.pathProbs().at(i).second) {
+
+                    return false;
+                }  
             }
 
             return true;
@@ -207,27 +218,35 @@ bool operator!=(const ReadPathProbabilities & lhs, const ReadPathProbabilities &
 
 bool operator<(const ReadPathProbabilities & lhs, const ReadPathProbabilities & rhs) { 
 
-    if (!doubleCompare(lhs.noiseProbability(), rhs.noiseProbability())) {
+    if (!Utils::doubleCompare(lhs.noiseProb(), rhs.noiseProb())) {
 
-        return (lhs.noiseProbability() < rhs.noiseProbability());    
+        return (lhs.noiseProb() < rhs.noiseProb());    
     } 
 
-    if (lhs.probabilities().size() != rhs.probabilities().size()) {
+    if (lhs.pathProbs().size() != rhs.pathProbs().size()) {
 
-        return (lhs.probabilities().size() < rhs.probabilities().size());
+        return (lhs.pathProbs().size() < rhs.pathProbs().size());
     }
 
-    for (size_t i = 0; i < lhs.probabilities().size(); ++i) {
+    for (size_t i = 0; i < lhs.pathProbs().size(); ++i) {
 
-        if (lhs.probabilities().at(i).first != rhs.probabilities().at(i).first) {
+        if (!Utils::doubleCompare(lhs.pathProbs().at(i).first, rhs.pathProbs().at(i).first)) {
 
-            return (lhs.probabilities().at(i).first < rhs.probabilities().at(i).first);    
+            return (lhs.pathProbs().at(i).first < rhs.pathProbs().at(i).first);    
+        }      
+
+        if (lhs.pathProbs().at(i).second.size() != rhs.pathProbs().at(i).second.size()) {
+
+            return (lhs.pathProbs().at(i).second.size() < rhs.pathProbs().at(i).second.size());    
         }  
 
-        if (!doubleCompare(lhs.probabilities().at(i).second, rhs.probabilities().at(i).second)) {
+        for (size_t j = 0; j < lhs.pathProbs().at(i).second.size(); ++j) {
 
-            return (lhs.probabilities().at(i).second < rhs.probabilities().at(i).second);    
-        }         
+            if (lhs.pathProbs().at(i).second.at(j) != rhs.pathProbs().at(i).second.at(j)) {
+
+                return (lhs.pathProbs().at(i).second.at(j) < rhs.pathProbs().at(i).second.at(j));    
+            } 
+        }   
     }
 
     if (lhs.readCount() != rhs.readCount()) {
@@ -240,11 +259,11 @@ bool operator<(const ReadPathProbabilities & lhs, const ReadPathProbabilities & 
 
 ostream & operator<<(ostream & os, const ReadPathProbabilities & read_path_probs) {
 
-    os << read_path_probs.readCount() << " | " << read_path_probs.noiseProbability() << " |";
+    os << read_path_probs.readCount() << " | " << read_path_probs.noiseProb() << " |";
 
-    for (auto & prob: read_path_probs.probabilities()) {
+    for (auto & path_probs: read_path_probs.pathProbs()) {
 
-        os << " " << prob.first << "," << prob.second;
+        os << " " << path_probs.first << ": " << path_probs.second;
     }
 
     return os;

--- a/src/read_path_probabilities.hpp
+++ b/src/read_path_probabilities.hpp
@@ -24,20 +24,19 @@ class ReadPathProbabilities {
     	ReadPathProbabilities(const uint32_t read_count_in, const double prob_precision_in);
 
         uint32_t readCount() const;
-        double noiseProbability() const;
-        const vector<pair<uint32_t, double> > & probabilities() const;
+        double noiseProb() const;
+        const vector<pair<double, vector<uint32_t> > > & pathProbs() const;
 
         void addReadCount(const uint32_t read_count_in);
-        void calcReadPathProbabilities(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end);
+        void calcAlignPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob);
 
-        bool mergeIdenticalReadPathProbabilities(const ReadPathProbabilities & probs_2);
-        vector<pair<double, vector<uint32_t> > > collapsedProbabilities() const;
+        bool quickMergeIdentical(const ReadPathProbabilities & probs_2);
 
     private:
 
         uint32_t read_count;
         double noise_prob;
-        vector<pair<uint32_t, double> > read_path_probs;
+        vector<pair<double, vector<uint32_t> > > path_probs;
         
         double prob_precision;
 };
@@ -50,3 +49,5 @@ ostream & operator<<(ostream & os, const ReadPathProbabilities & read_path_probs
 
 
 #endif
+
+

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "gbwt/dynamic_gbwt.h"
+#include "gbwt/fast_locate.h"
 
 #include "../alignment_path_finder.hpp"
 #include "../utils.hpp"
@@ -12,10 +13,10 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     const string graph_str = R"(
     	{
     		"node": [
-    			{"id": 1, "sequence": "GGGG"},
+    			{"id": 1, "sequence": "AAAA"},
     			{"id": 2, "sequence": "A"},
-    			{"id": 3, "sequence": "C"},
-    			{"id": 4, "sequence": "TTTTTTTT"}
+    			{"id": 3, "sequence": "A"},
+    			{"id": 4, "sequence": "AAAAAAAA"}
     		],
             "edge": [
                 {"from": 1, "to": 2},
@@ -27,10 +28,10 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     )";
 
 	vg::Graph graph;
-	json2pb(graph, graph_str);
+	Utils::json2pb(graph, graph_str);
 
-    vector<uint32_t> node_seq_lengths = {0, 4, 1, 1, 8};
-    function<size_t(const uint32_t)> node_seq_length_func = [&](const uint32_t node_id) { return node_seq_lengths.at(node_id); };
+    vector<uint32_t> node_frag_lengths = {0, 4, 1, 1, 8};
+    function<size_t(const uint32_t)> node_frag_length_func = [&](const uint32_t node_id) { return node_frag_lengths.at(node_id); };
 
 	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(4, true)));
@@ -76,50 +77,62 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
                 		"position": {"node_id": 4},
                     	"edit": [
                             {"from_length": 1, "to_length": 1},
-                            {"from_length": 2, "to_length": 2, "sequence": "AG"},
+                            {"from_length": 2, "to_length": 2, "sequence": "AA"},
                             {"from_length": 2, "to_length": 2}
                     	]
                 	}
                 ]
            	},
+            "sequence": "AAAAAAAA",
            	"mapping_quality": 10,
-           	"score": 1 
+           	"score": 4
         }
     )";
 
     vg::Alignment alignment_1;
-    json2pb(alignment_1, alignment_1_str);
+    Utils::json2pb(alignment_1, alignment_1_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(!paths_index.index().bidirectional());
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000);
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 3);
+
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000, 0, true, 0);
 
     auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
-    REQUIRE(alignment_paths.size() == 2);
+    REQUIRE(alignment_paths.size() == 3);
 
     SECTION("Single-end read alignment finds alignment path(s)") {    
 
-        REQUIRE(alignment_paths.front().seq_length == 8);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({0}));
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 8);
         REQUIRE(alignment_paths.front().min_mapq == 10);
-        REQUIRE(alignment_paths.front().score_sum == 1);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));
+        REQUIRE(alignment_paths.front().score_sum == 4);
 
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.front().seq_length);
-        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.front().min_mapq);
-        REQUIRE(alignment_paths.back().score_sum == alignment_paths.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == numeric_limits<int32_t>::lowest());
     }
 
     SECTION("Reverse-complement single-end read alignment finds alignment path(s)") {
 
-        auto alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_seq_length_func);
+        auto alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_frag_length_func);
+        alignment_1_rc.set_sequence("AAAAAAAA");
         
         auto alignment_paths_rc = alignment_path_finder.findAlignmentPaths(alignment_1_rc);
-        REQUIRE(alignment_paths_rc.size() == 2);
+        REQUIRE(alignment_paths_rc.size() == 3);
 
-        REQUIRE(alignment_paths_rc.front() == alignment_paths.back());
-        REQUIRE(alignment_paths_rc.back() == alignment_paths.front());
+        REQUIRE(alignment_paths_rc == alignment_paths);
     }
 
     SECTION("Soft-clipped single-end read alignment finds alignment path(s)") {
@@ -137,7 +150,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
         alignment_1.mutable_path()->mutable_mapping(2)->mutable_edit(2)->set_sequence("CC");
 
         auto alignment_paths_sc = alignment_path_finder.findAlignmentPaths(alignment_1);
-        REQUIRE(alignment_paths_sc.size() == 2);
+        REQUIRE(alignment_paths_sc.size() == 3);
 
         REQUIRE(alignment_paths_sc == alignment_paths);
     }
@@ -165,18 +178,25 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
         gbwt::GBWT gbwt_index_bd;
         gbwt_index_bd.load(gbwt_stream_bd);
 
-        PathsIndex paths_index_bd(gbwt_index_bd, graph);
-        REQUIRE(paths_index_bd.index().bidirectional() == true);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000);
+        PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
+
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index_bd.numberOfPaths() == 2);
+
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000, 0, true, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findAlignmentPaths(alignment_1);
-        REQUIRE(alignment_paths_bd.size() == 1);
+        REQUIRE(alignment_paths_bd.size() == 2);
 
-        REQUIRE(alignment_paths_bd.front().seq_length == alignment_paths.front().seq_length);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_bd.front().gbwt_search) == vector<gbwt::size_type>({0}));
+        REQUIRE(alignment_paths_bd.front().is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths_bd.front().frag_length == alignment_paths.front().frag_length);
         REQUIRE(alignment_paths_bd.front().min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths_bd.front().score_sum == alignment_paths.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_bd.front().search_state) == vector<gbwt::size_type>({0}));
+
+        REQUIRE(alignment_paths_bd.back() == alignment_paths.back());
     }
 }
     
@@ -185,11 +205,11 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
     const string graph_str = R"(
         {
             "node": [
-                {"id": 1, "sequence": "GGGG"},
+                {"id": 1, "sequence": "AAAA"},
                 {"id": 2, "sequence": "A"},
-                {"id": 3, "sequence": "C"},
-                {"id": 4, "sequence": "TTTTTTTT"},
-                {"id": 5, "sequence": "CC"},
+                {"id": 3, "sequence": "A"},
+                {"id": 4, "sequence": "AAAAAAAA"},
+                {"id": 5, "sequence": "AA"},
                 {"id": 6, "sequence": "AAAAAAA"}
             ],
             "edge": [
@@ -206,10 +226,10 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
     )";
 
     vg::Graph graph;
-    json2pb(graph, graph_str);
+    Utils::json2pb(graph, graph_str);
 
-    vector<uint32_t> node_seq_lengths = {0, 4, 1, 1, 8, 2, 7};
-    function<size_t(const uint32_t)> node_seq_length_func = [&](const uint32_t node_id) { return node_seq_lengths.at(node_id); };
+    vector<uint32_t> node_frag_lengths = {0, 4, 1, 1, 8, 2, 7};
+    function<size_t(const uint32_t)> node_frag_length_func = [&](const uint32_t node_id) { return node_frag_lengths.at(node_id); };
 
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(6, true)));
@@ -269,13 +289,14 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
                     }
                 ]
             },
+            "sequence": "AAAAAAAA",
             "mapping_quality": 10,
-            "score": 1 
+            "score": 8
         }
     )";
 
     vg::Alignment alignment_1;
-    json2pb(alignment_1, alignment_1_str);
+    Utils::json2pb(alignment_1, alignment_1_str);
 
     const string alignment_2_str = R"(
         {
@@ -285,50 +306,64 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
                         "position": {"node_id": 6, "offset": 1, "is_reverse": true},
                         "edit": [
                             {"from_length": 2, "to_length": 2},
-                            {"from_length": 1, "to_length": 1, "sequence": "T"},
+                            {"from_length": 1, "to_length": 1, "sequence": "A"},
                             {"from_length": 1, "to_length": 1}
                         ]
                     }
                 ]
             },
+            "sequence": "AAAA",
             "mapping_quality": 20,
-            "score": 2 
+            "score": 2
         }
     )";
 
     vg::Alignment alignment_2;
-    json2pb(alignment_2, alignment_2_str);
+    Utils::json2pb(alignment_2, alignment_2_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(!paths_index.index().bidirectional());
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000);
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 4);
 
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000, 0, true, 0);
+    
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-    REQUIRE(alignment_paths.size() == 3);
+    REQUIRE(alignment_paths.size() == 4);
 
     SECTION("Paired-end read alignment finds alignment path(s)") {
 
-        REQUIRE(alignment_paths.front().seq_length == 19);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({0}));
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 19);
         REQUIRE(alignment_paths.front().min_mapq == 10);
-        REQUIRE(alignment_paths.front().score_sum == 3);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));
+        REQUIRE(alignment_paths.front().score_sum == 10);
 
-        REQUIRE(alignment_paths.at(1).seq_length == 17);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({2}));
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == 17);
         REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({2}));
 
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).seq_length);
-        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
-        REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(2).gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths.at(2).is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths.at(2).frag_length == alignment_paths.at(1).frag_length);
+        REQUIRE(alignment_paths.at(2).min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.at(2).score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(2).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(2).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == numeric_limits<int32_t>::lowest());
     }
 
     SECTION("Incorrect oriented paired-end read alignment finds empty alignment path") {
 
-        auto alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_seq_length_func);
-        
+        auto alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_frag_length_func);
+        alignment_2_rc.set_sequence("AAAA");
+
         auto alignment_paths_rc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2_rc);
         REQUIRE(alignment_paths_rc.empty());
     }
@@ -347,10 +382,13 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         new_edit->set_from_length(2);
         new_edit->set_to_length(2);
 
+        alignment_2.set_sequence(alignment_2.sequence() + "AAAA");      
+
         auto alignment_paths_ext = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ext.size() == 1);
+        REQUIRE(alignment_paths_ext.size() == 2);
 
         REQUIRE(alignment_paths_ext.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_ext.back() == alignment_paths.back());
 
         new_mapping = alignment_2.mutable_path()->add_mapping();
         new_mapping->mutable_position()->set_node_id(4);
@@ -361,10 +399,13 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
 
+        alignment_2.set_sequence(alignment_2.sequence() + "A");        
+
         alignment_paths_ext = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ext.size() == 1);
+        REQUIRE(alignment_paths_ext.size() == 2);
 
         REQUIRE(alignment_paths_ext.front() == alignment_paths.front());             
+        REQUIRE(alignment_paths_ext.back() == alignment_paths.back());
     }
 
     SECTION("Partial overlapping paired-end read alignment finds alignment path(s)") {
@@ -381,14 +422,19 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         new_edit->set_from_length(5);
         new_edit->set_to_length(5);
 
+        alignment_2.set_sequence(alignment_2.sequence() + "AAAAAAA");
+
         auto alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ov.size() == 2);
+        REQUIRE(alignment_paths_ov.size() == 3);
 
         REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_ov.at(1) == alignment_paths.at(2));
         REQUIRE(alignment_paths_ov.back() == alignment_paths.back());
 
         new_edit->set_from_length(8);
         new_edit->set_to_length(8);
+
+        alignment_2.set_sequence(alignment_2.sequence() + "AAA");
 
         new_mapping = alignment_2.mutable_path()->add_mapping();
         new_mapping->mutable_position()->set_node_id(2);
@@ -399,10 +445,13 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
 
+        alignment_2.set_sequence(alignment_2.sequence() + "A");
+
         alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ov.size() == 2);
+        REQUIRE(alignment_paths_ov.size() == 3);
 
         REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_ov.at(1) == alignment_paths.at(2));
         REQUIRE(alignment_paths_ov.back() == alignment_paths.back());
 
         new_mapping = alignment_2.mutable_path()->add_mapping();
@@ -414,44 +463,61 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
 
+        alignment_2.set_sequence(alignment_2.sequence() + "A");
+
         alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ov.size() == 2);
+        REQUIRE(alignment_paths_ov.size() == 3);
 
         REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_ov.at(1) == alignment_paths.at(2));
         REQUIRE(alignment_paths_ov.back() == alignment_paths.back());
     }
 
     SECTION("Perfect overlapping paired-end read alignment finds alignment path(s)") {
 
-        auto alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_seq_length_func);
+        auto alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_frag_length_func);
+        alignment_1_rc.set_sequence("AAAAAAAA");
 
         auto alignment_paths_ov_1 = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_1_rc);
-        REQUIRE(alignment_paths_ov_1.size() == 2);
+        REQUIRE(alignment_paths_ov_1.size() == 3);
 
-        REQUIRE(alignment_paths_ov_1.front().seq_length == 8);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().gbwt_search) == vector<gbwt::size_type>({0, 2}));
+        REQUIRE(!alignment_paths_ov_1.front().is_multimap);
+        REQUIRE(alignment_paths_ov_1.front().frag_length == 8);
         REQUIRE(alignment_paths_ov_1.front().min_mapq == 10);
-        REQUIRE(alignment_paths_ov_1.front().score_sum == 2);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().search_state) == vector<gbwt::size_type>({0, 2}));
+        REQUIRE(alignment_paths_ov_1.front().score_sum == 16);
 
-        REQUIRE(alignment_paths_ov_1.back().seq_length == alignment_paths_ov_1.front().seq_length);
-        REQUIRE(alignment_paths_ov_1.back().min_mapq == alignment_paths_ov_1.front().min_mapq);
-        REQUIRE(alignment_paths_ov_1.back().score_sum == alignment_paths_ov_1.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.back().search_state) == vector<gbwt::size_type>({1}));
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.at(1).gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths_ov_1.at(1).is_multimap == alignment_paths_ov_1.front().is_multimap);
+        REQUIRE(alignment_paths_ov_1.at(1).frag_length == alignment_paths_ov_1.front().frag_length);
+        REQUIRE(alignment_paths_ov_1.at(1).min_mapq == alignment_paths_ov_1.front().min_mapq);
+        REQUIRE(alignment_paths_ov_1.at(1).score_sum == alignment_paths_ov_1.front().score_sum);
 
-        auto alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_seq_length_func);
+        REQUIRE(alignment_paths_ov_1.back() == alignment_paths.back());
+
+        auto alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_frag_length_func);
+        alignment_2_rc.set_sequence("AAAA");
 
         auto alignment_paths_ov_2 = alignment_path_finder.findPairedAlignmentPaths(alignment_2, alignment_2_rc);
-        REQUIRE(alignment_paths_ov_2.size() == 2);
+        REQUIRE(alignment_paths_ov_2.size() == 3);
 
-        REQUIRE(alignment_paths_ov_2.front().seq_length == 4);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(!alignment_paths_ov_2.front().is_multimap);
+        REQUIRE(alignment_paths_ov_2.front().frag_length == 4);
         REQUIRE(alignment_paths_ov_2.front().min_mapq == 20);
         REQUIRE(alignment_paths_ov_2.front().score_sum == 4);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().search_state) == vector<gbwt::size_type>({1}));
 
-        REQUIRE(alignment_paths_ov_2.back().seq_length == alignment_paths_ov_2.front().seq_length);
-        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.front().min_mapq);
-        REQUIRE(alignment_paths_ov_2.back().score_sum == alignment_paths_ov_2.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.back().search_state) == vector<gbwt::size_type>({0, 2, 3}));
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.at(1).gbwt_search) == vector<gbwt::size_type>({0, 2, 3}));
+        REQUIRE(alignment_paths_ov_2.at(1).is_multimap == alignment_paths_ov_2.front().is_multimap);
+        REQUIRE(alignment_paths_ov_2.at(1).frag_length == alignment_paths_ov_2.front().frag_length);
+        REQUIRE(alignment_paths_ov_2.at(1).min_mapq == alignment_paths_ov_2.front().min_mapq);
+        REQUIRE(alignment_paths_ov_2.at(1).score_sum == alignment_paths_ov_2.front().score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.back().gbwt_search).empty());
+        REQUIRE(alignment_paths_ov_2.back().is_multimap == alignment_paths_ov_2.at(1).is_multimap);
+        REQUIRE(alignment_paths_ov_2.back().frag_length == 0);
+        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.at(1).min_mapq);
+        REQUIRE(alignment_paths_ov_2.back().score_sum == numeric_limits<int32_t>::lowest());
     }
 
     SECTION("Incorrect overlapping paired-end read alignment finds empty alignment path") {
@@ -467,6 +533,8 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         auto new_edit = new_mapping->add_edit();
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
+
+        alignment_2.set_sequence(alignment_2.sequence() + "AAA");
 
         auto alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_ov.empty());
@@ -488,39 +556,26 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         gbwt::GBWT gbwt_index_bd;
         gbwt_index_bd.load(gbwt_stream_bd);
 
-        PathsIndex paths_index_bd(gbwt_index_bd, graph);
-        REQUIRE(paths_index_bd.index().bidirectional() == true);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
+        PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
+        
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index_bd.numberOfPaths() == 3);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000);
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000, 0, true, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_bd.size() == 2);
+        REQUIRE(alignment_paths_bd.size() == 3);
 
         REQUIRE(alignment_paths_bd.front() == alignment_paths.front());
-        REQUIRE(alignment_paths_bd.at(1) == alignment_paths.at(1));     
-    }
 
-    SECTION("Alignment pairs from a paired-end alignment are filtered based on length") {
+        REQUIRE(paths_index_bd.locatePathIds(alignment_paths_bd.at(1).gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths_bd.at(1).is_multimap == alignment_paths.at(1).is_multimap);        
+        REQUIRE(alignment_paths_bd.at(1).frag_length == alignment_paths.at(1).frag_length);
+        REQUIRE(alignment_paths_bd.at(1).min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths_bd.at(1).score_sum == alignment_paths.at(1).score_sum);
 
-        alignment_path_finder.setMaxPairSeqLength(19);
-
-        auto alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.size() == 3);
-        
-        REQUIRE(alignment_paths_len == alignment_paths);
-
-        alignment_path_finder.setMaxPairSeqLength(18);
-
-        alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.size() == 2);
-        
-        REQUIRE(alignment_paths_len.front() == alignment_paths.at(1));
-        REQUIRE(alignment_paths_len.back() == alignment_paths.back());
-
-        alignment_path_finder.setMaxPairSeqLength(10);
-
-        alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.empty());
+        REQUIRE(alignment_paths_bd.back() == alignment_paths.back());
     }
 }
 
@@ -529,9 +584,9 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
     const string graph_str = R"(
         {
             "node": [
-                {"id": 1, "sequence": "GGGG"},
+                {"id": 1, "sequence": "AAAA"},
                 {"id": 2, "sequence": "AAAA"},
-                {"id": 3, "sequence": "CCCC"},
+                {"id": 3, "sequence": "AAAA"}
             ],
             "edge": [
                 {"from": 1, "to": 2},
@@ -542,10 +597,7 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
     )";
 
     vg::Graph graph;
-    json2pb(graph, graph_str);
-
-    vector<uint32_t> node_seq_lengths = {0, 4, 4, 4, 4};
-    function<size_t(const uint32_t)> node_seq_length_func = [&](const uint32_t node_id) { return node_seq_lengths.at(node_id); };
+    Utils::json2pb(graph, graph_str);
 
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(6, true)));
@@ -586,13 +638,14 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
                     }
                 ]
             },
+            "sequence": "AA",
             "mapping_quality": 10,
-            "score": 1 
+            "score": 2 
         }
     )";
 
     vg::Alignment alignment_1;
-    json2pb(alignment_1, alignment_1_str);
+    Utils::json2pb(alignment_1, alignment_1_str);
 
     const string alignment_2_str = R"(
         {
@@ -606,38 +659,51 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
                     }
                 ]
             },
+            "sequence": "AA",
             "mapping_quality": 20,
             "score": 2 
         }
     )";
 
     vg::Alignment alignment_2;
-    json2pb(alignment_2, alignment_2_str);
+    Utils::json2pb(alignment_2, alignment_2_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(!paths_index.index().bidirectional());
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000);
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 3);
+
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", 1000, 0, true, 0);
 
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-    REQUIRE(alignment_paths.size() == 3);
+    REQUIRE(alignment_paths.size() == 4);
 
     SECTION("Paired-end read alignment finds circular alignment path(s)") {
 
-        REQUIRE(alignment_paths.front().seq_length == 10);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({1}));                
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 18);
         REQUIRE(alignment_paths.front().min_mapq == 10);
-        REQUIRE(alignment_paths.front().score_sum == 3);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));        
+        REQUIRE(alignment_paths.front().score_sum == 4);
 
-        REQUIRE(alignment_paths.at(1).seq_length == 18);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({0}));        
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == 10);
         REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
         REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({1}));                
 
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).seq_length);
-        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
-        REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({2}));   
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(2).gbwt_search) == vector<gbwt::size_type>({2}));   
+        REQUIRE(alignment_paths.at(2).is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths.at(2).frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths.at(2).min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.at(2).score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(2).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(2).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == numeric_limits<int32_t>::lowest());
     }
 
     SECTION("Non-circular paired-end read alignment finds non-circular alignment path(s)") {
@@ -651,6 +717,8 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         new_edit->set_from_length(4);
         new_edit->set_to_length(4);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
+
         new_mapping = alignment_1.mutable_path()->add_mapping();
         new_mapping->mutable_position()->set_node_id(3);
         new_mapping->mutable_position()->set_offset(0);
@@ -660,10 +728,13 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
 
-        auto alignment_paths_ncirc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ncirc.size() == 1);
+        alignment_1.set_sequence(alignment_1.sequence() + "A");
 
-        REQUIRE(alignment_paths_ncirc.front() == alignment_paths.front());
+        auto alignment_paths_ncirc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_ncirc.size() == 2);
+
+        REQUIRE(alignment_paths_ncirc.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_ncirc.back() == alignment_paths.back());
     }
 
     SECTION("Circular paired-end read alignment finds circular alignment path(s)") {
@@ -677,6 +748,8 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         new_edit->set_from_length(4);
         new_edit->set_to_length(4);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
+
         for (uint32_t i = 0; i < 2; i++) {
 
             new_mapping = alignment_1.mutable_path()->add_mapping();
@@ -688,10 +761,13 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
             new_edit->set_from_length(4);
             new_edit->set_to_length(4);
 
-            auto alignment_paths_circ = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-            REQUIRE(alignment_paths_circ.size() == 2);
+            alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
 
-            REQUIRE(alignment_paths_circ.front() == alignment_paths.at(1));
+            auto alignment_paths_circ = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+            REQUIRE(alignment_paths_circ.size() == 3);
+
+            REQUIRE(alignment_paths_circ.front() == alignment_paths.front());
+            REQUIRE(alignment_paths_circ.at(1) == alignment_paths.at(2));
             REQUIRE(alignment_paths_circ.back() == alignment_paths.back());
         }
     }
@@ -707,6 +783,8 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         new_edit->set_from_length(4);
         new_edit->set_to_length(4);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
+
         new_mapping = alignment_1.mutable_path()->add_mapping();
         new_mapping->mutable_position()->set_node_id(3);
         new_mapping->mutable_position()->set_offset(0);
@@ -716,10 +794,13 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         new_edit->set_from_length(4);
         new_edit->set_to_length(4);
 
-        auto alignment_paths_ncirc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ncirc.size() == 1);
+        alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
 
-        REQUIRE(alignment_paths_ncirc.front() == alignment_paths.front());
+        auto alignment_paths_ncirc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_ncirc.size() == 2);
+
+        REQUIRE(alignment_paths_ncirc.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_ncirc.back() == alignment_paths.back());
     }
 
     SECTION("Partial overlapping circular paired-end read alignment finds circular alignment path(s)") {
@@ -734,10 +815,14 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
             auto new_edit = new_mapping->add_edit();
             new_edit->set_from_length(4);
             new_edit->set_to_length(4);
+    
+            alignment_1.set_sequence(alignment_1.sequence() + "AAAA");
         }
 
         alignment_2.mutable_path()->mutable_mapping(0)->mutable_edit(0)->set_from_length(4);
         alignment_2.mutable_path()->mutable_mapping(0)->mutable_edit(0)->set_to_length(4);
+
+        alignment_2.set_sequence(alignment_2.sequence() + "AA");
 
         for (uint32_t i = 0; i < 3; i++) {
 
@@ -749,13 +834,15 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
             auto new_edit = new_mapping->add_edit();
             new_edit->set_from_length(4);
             new_edit->set_to_length(4);
+
+            alignment_2.set_sequence(alignment_2.sequence() + "AAAA");
         }
 
         auto alignment_paths_circ = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_circ.size() == 2);
+        REQUIRE(alignment_paths_circ.size() == 3);
 
-
-        REQUIRE(alignment_paths_circ.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_circ.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_circ.at(1) == alignment_paths.at(2));
         REQUIRE(alignment_paths_circ.back() == alignment_paths.back());
     }
 
@@ -774,20 +861,30 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         gbwt::GBWT gbwt_index_bd;
         gbwt_index_bd.load(gbwt_stream_bd);
 
-        PathsIndex paths_index_bd(gbwt_index_bd, graph);
-        REQUIRE(paths_index_bd.index().bidirectional() == true);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
+        PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
+        
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000);
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000, 0, true, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_bd.size() == 2);
+        REQUIRE(alignment_paths_bd.size() == 3);
 
-        REQUIRE(alignment_paths_bd.front() == alignment_paths.front());
+        REQUIRE(paths_index_bd.locatePathIds(alignment_paths_bd.front().gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths_bd.front().is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths_bd.front().frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths_bd.front().min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths_bd.front().score_sum == alignment_paths.front().score_sum);
 
-        REQUIRE(alignment_paths_bd.back().seq_length == alignment_paths.back().seq_length);
-        REQUIRE(alignment_paths_bd.back().min_mapq == alignment_paths.back().min_mapq);
-        REQUIRE(alignment_paths_bd.back().score_sum == alignment_paths.back().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_bd.back().search_state) == vector<gbwt::size_type>({1}));                
+        REQUIRE(paths_index.locatePathIds(alignment_paths_bd.at(1).gbwt_search) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths_bd.at(1).is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths_bd.at(1).frag_length == alignment_paths.at(1).frag_length);
+        REQUIRE(alignment_paths_bd.at(1).min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths_bd.at(1).score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(alignment_paths_bd.back() == alignment_paths.back());
     }
 }
 
@@ -797,27 +894,27 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
         {
             "node": [
                 {"id": 1, "sequence": "A"},
-                {"id": 2, "sequence": "C"},
-                {"id": 3, "sequence": "TTT"},
-                {"id": 4, "sequence": "TT"},
-                {"id": 5, "sequence": "GGG"},
-                {"id": 6, "sequence": "AGG"},
+                {"id": 2, "sequence": "A"},
+                {"id": 3, "sequence": "AAA"},
+                {"id": 4, "sequence": "AA"},
+                {"id": 5, "sequence": "AAA"},
+                {"id": 6, "sequence": "AAA"}
             ],
             "edge": [
                 {"from": 1, "to": 3},
                 {"from": 2, "to": 3},
                 {"from": 3, "to": 4},
                 {"from": 4, "to": 5},
-                {"from": 5, "to": 6}
+                {"from": 4, "to": 6}
             ]
         }
     )";
 
     vg::Graph graph;
-    json2pb(graph, graph_str);
+    Utils::json2pb(graph, graph_str);
 
-    vector<uint32_t> node_seq_lengths = {0, 1, 1, 3, 2, 3, 3};
-    function<size_t(const uint32_t)> node_seq_length_func = [&](const uint32_t node_id) { return node_seq_lengths.at(node_id); };
+    vector<uint32_t> node_frag_lengths = {0, 1, 1, 3, 2, 3, 3};
+    function<size_t(const uint32_t)> node_frag_length_func = [&](const uint32_t node_id) { return node_frag_lengths.at(node_id); };
 
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(6, true)));
@@ -862,7 +959,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
                         ]
                     },
                     "next": [2],
-                    "score": 4
+                    "score": 1
                 },
                 {
                     "path": {
@@ -876,7 +973,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
                         ]
                     },
                     "next": [2],
-                    "score": 1
+                    "score": -1
                 },
                 {                
                     "path": {
@@ -896,7 +993,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
                         ]
                     },
                     "next": [3,4],
-                    "score": 6
+                    "score": 5
                 },
                 {
                     "path": {
@@ -909,7 +1006,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
                             }
                         ]
                     },
-                    "score": 4
+                    "score": 2
                 },
                 {
                     "path": {
@@ -917,52 +1014,64 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
                             {
                                 "position": {"node_id": 6},
                                 "edit": [
-                                    {"from_length": 1, "to_length": 1, "sequence": "G"},
+                                    {"from_length": 1, "to_length": 1, "sequence": "A"},
                                     {"from_length": 1, "to_length": 1}
                                 ]
                             }
                         ]
                     },
-                    "score": 2
+                    "score": 0
                 }
             ],
+            "sequence": "AAAAAAAA",
             "mapping_quality": 10
         }
     )";
 
     vg::MultipathAlignment alignment_1;
-    json2pb(alignment_1, alignment_1_str);
+    Utils::json2pb(alignment_1, alignment_1_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(!paths_index.index().bidirectional());
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
+    
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 2);
 
-    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", 1000);
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", 1000, 0, true, 0);
     
     auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
-    REQUIRE(alignment_paths.size() == 2);
+    REQUIRE(alignment_paths.size() == 3);
 
     SECTION("Single-end multipath read alignment finds alignment path(s)") {
 
-        REQUIRE(alignment_paths.front().seq_length == 8);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({0}));
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 8);
         REQUIRE(alignment_paths.front().min_mapq == 10);
-        REQUIRE(alignment_paths.front().score_sum == 14);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({0}));                
-  
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.front().seq_length);
-        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.front().min_mapq);
-        REQUIRE(alignment_paths.back().score_sum == 12);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({1}));                
+        REQUIRE(alignment_paths.front().score_sum == 8);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({1}));               
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths.at(1).score_sum == 6);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == -2164501);
     }
 
     SECTION("Reverse-complement single-end multipath read alignment finds alignment path(s)") {
 
-        auto alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_seq_length_func);
+        auto alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_frag_length_func);
+        alignment_1_rc.set_sequence("AAAAAAAA");
         
         auto alignment_paths_rc = alignment_path_finder.findAlignmentPaths(alignment_1_rc);
-        REQUIRE(alignment_paths_rc.size() == 2);
+        REQUIRE(alignment_paths_rc.size() == 3);
 
-        REQUIRE(alignment_paths_rc.front() == alignment_paths.back());
-        REQUIRE(alignment_paths_rc.back() == alignment_paths.front());
+        REQUIRE(alignment_paths_rc == alignment_paths);
     }
 
     SECTION("Soft-clipped single-end multipath read alignment finds alignment path(s)") {
@@ -973,10 +1082,10 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
         auto new_edit = alignment_1.mutable_subpath(3)->mutable_path()->mutable_mapping(0)->add_edit();
         new_edit->set_from_length(0);
         new_edit->set_to_length(1);
-        new_edit->set_sequence("C");
+        new_edit->set_sequence("A");
 
         auto alignment_paths_sc = alignment_path_finder.findAlignmentPaths(alignment_1);
-        REQUIRE(alignment_paths_sc.size() == 2);
+        REQUIRE(alignment_paths_sc.size() == 3);
 
         REQUIRE(alignment_paths_sc == alignment_paths);
     }
@@ -996,21 +1105,48 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
         gbwt::GBWT gbwt_index_bd;
         gbwt_index_bd.load(gbwt_stream_bd);
 
-        PathsIndex paths_index_bd(gbwt_index_bd, graph);
-        REQUIRE(paths_index_bd.index().bidirectional() == true);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
+        PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
+        
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000);
-    
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000, 0, true, 0);
+
         auto alignment_paths_bd = alignment_path_finder_bd.findAlignmentPaths(alignment_1);
-        REQUIRE(alignment_paths_bd.size() == 2);
+        REQUIRE(alignment_paths_bd.size() == 3);
 
-        REQUIRE(alignment_paths_bd.front() == alignment_paths.front());
-        REQUIRE(alignment_paths_bd.back().seq_length == alignment_paths.back().seq_length);
+        REQUIRE(paths_index_bd.locatePathIds(alignment_paths_bd.front().gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths_bd.front().is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths_bd.front().frag_length == alignment_paths.at(1).frag_length);
+        REQUIRE(alignment_paths_bd.front().min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths_bd.front().score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(alignment_paths_bd.at(1) == alignment_paths.front());
+
+        REQUIRE(alignment_paths_bd.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_bd.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_bd.back().frag_length == alignment_paths.back().frag_length);
         REQUIRE(alignment_paths_bd.back().min_mapq == alignment_paths.back().min_mapq);
-        REQUIRE(alignment_paths_bd.back().score_sum == alignment_paths.back().score_sum);
-        REQUIRE(gbwt::Node::id(alignment_paths_bd.back().search_state.node) == 6);
-        REQUIRE(paths_index_bd.locatePathIds(alignment_paths_bd.back().search_state) == paths_index.locatePathIds(alignment_paths.back().search_state));
+        REQUIRE(alignment_paths_bd.back().score_sum == -2827626);
     }
+
+    SECTION("Alignment pairs from a single-end multipath alignment does not estimate missing path noise probability") {
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", 1000, 0, false, 0);
+
+        auto alignment_paths_nm = alignment_path_finder_nm.findAlignmentPaths(alignment_1);
+        REQUIRE(alignment_paths_nm.size() == 3);
+
+        REQUIRE(alignment_paths_nm.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_nm.at(1)== alignment_paths.at(1));
+
+        REQUIRE(alignment_paths_nm.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_nm.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_nm.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_nm.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_nm.back().score_sum ==  numeric_limits<int32_t>::lowest());
+    }    
 }
 
 TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment") {
@@ -1019,15 +1155,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         {
             "node": [
                 {"id": 1, "sequence": "A"},
-                {"id": 2, "sequence": "G"},
-                {"id": 3, "sequence": "CC"},
-                {"id": 4, "sequence": "GGG"},
-                {"id": 5, "sequence": "CC"},
+                {"id": 2, "sequence": "AAAA"},
+                {"id": 3, "sequence": "AA"},
+                {"id": 4, "sequence": "AAAA"},
+                {"id": 5, "sequence": "AA"},
                 {"id": 6, "sequence": "A"},
-                {"id": 7, "sequence": "G"},
-                {"id": 8, "sequence": "TTT"},
+                {"id": 7, "sequence": "AA"},
+                {"id": 8, "sequence": "AAA"},
+                {"id": 9, "sequence": "AAA"}
             ],
             "edge": [
+                {"from": 1, "to": 2},
                 {"from": 1, "to": 3},
                 {"from": 2, "to": 3},
                 {"from": 3, "to": 4},
@@ -1035,17 +1173,19 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                 {"from": 4, "to": 5},
                 {"from": 5, "to": 6},
                 {"from": 5, "to": 7},
-                {"from": 6, "to": 8},
-                {"from": 7, "to": 8}
+                {"from": 5, "to": 8},
+                {"from": 6, "to": 9},
+                {"from": 7, "to": 9},
+                {"from": 8, "to": 9}
             ]
         }
     )";
 
     vg::Graph graph;
-    json2pb(graph, graph_str);
+    Utils::json2pb(graph, graph_str);
 
-    vector<uint32_t> node_seq_lengths = {0, 1, 1, 2, 3, 2, 1, 1, 3};
-    function<size_t(const uint32_t)> node_seq_length_func = [&](const uint32_t node_id) { return node_seq_lengths.at(node_id); };
+    vector<uint32_t> node_frag_lengths = {0, 1, 4, 2, 4, 2, 1, 2, 3, 3};
+    function<size_t(const uint32_t)> node_frag_length_func = [&](const uint32_t node_id) { return node_frag_lengths.at(node_id); };
 
     gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(8, true)));
@@ -1057,14 +1197,14 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
     gbwt_thread_1[1] = gbwt::Node::encode(3, false);
     gbwt_thread_1[2] = gbwt::Node::encode(5, false);
     gbwt_thread_1[3] = gbwt::Node::encode(6, false);
-    gbwt_thread_1[4] = gbwt::Node::encode(8, false);
+    gbwt_thread_1[4] = gbwt::Node::encode(9, false);
 
     gbwt_thread_2[0] = gbwt::Node::encode(2, false);
     gbwt_thread_2[1] = gbwt::Node::encode(3, false);
     gbwt_thread_2[2] = gbwt::Node::encode(4, false);
     gbwt_thread_2[3] = gbwt::Node::encode(5, false);
     gbwt_thread_2[4] = gbwt::Node::encode(7, false);
-    gbwt_thread_2[5] = gbwt::Node::encode(8, false);
+    gbwt_thread_2[5] = gbwt::Node::encode(9, false);
 
     gbwt_builder.insert(gbwt_thread_1, false);
     gbwt_builder.insert(gbwt_thread_2, true);
@@ -1079,8 +1219,23 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     const string alignment_1_str = R"(
         {
-            "start": [0,1],
+            "start": [0,1,2],
             "subpath": [
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 1},
+                                "edit": [
+                                    {"to_length": 3, "sequence": "AAA"},
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [3],
+                    "score": 1
+                },
                 {
                     "path": {
                         "mapping": [
@@ -1089,10 +1244,17 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                                 "edit": [
                                     {"from_length": 1, "to_length": 1}
                                 ]
-                            }
+                            },
+                            {
+                                "position": {"node_id": 2},
+                                "edit": [
+                                    {"from_length": 1},
+                                    {"from_length": 3, "to_length": 3}
+                                ]
+                            },                            
                         ]
                     },
-                    "next": [2],
+                    "next": [3],
                     "score": 3
                 },
                 {
@@ -1101,13 +1263,13 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                             {
                                 "position": {"node_id": 2},
                                 "edit": [
-                                    {"from_length": 1, "to_length": 1, "sequence": "A"}
+                                    {"from_length": 4, "to_length": 4}
                                 ]
                             }
                         ]
                     },
-                    "next": [2],
-                    "score": 1
+                    "next": [3],
+                    "score": 4
                 },
                 {                
                     "path": {
@@ -1120,15 +1282,16 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                             },
                         ]
                     },
-                    "score": 7
+                    "score": 2
                 }
             ],
+            "sequence": "AAAAAA",
             "mapping_quality": 10
         }
     )";
 
     vg::MultipathAlignment alignment_1;
-    json2pb(alignment_1, alignment_1_str);
+    Utils::json2pb(alignment_1, alignment_1_str);
 
     const string alignment_2_str = R"(
         {
@@ -1138,14 +1301,28 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                     "path": {
                         "mapping": [
                             {
-                                "position": {"node_id": 8, "offset": 2, "is_reverse": true},
+                                "position": {"node_id": 9, "offset": 2, "is_reverse": true},
                                 "edit": [
                                     {"from_length": 1, "to_length": 1}
                                 ]
                             }
                         ]
                     },
-                    "next": [1,2],
+                    "next": [1,2,5],
+                    "score": 1
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 8, "is_reverse": true},
+                                "edit": [
+                                    {"from_length": 3, "to_length": 3}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [8],
                     "score": 3
                 },
                 {
@@ -1160,7 +1337,35 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                         ]
                     },
                     "next": [3],
-                    "score": 4
+                    "score": 1
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 7, "offset": 1, "is_reverse": true},
+                                "edit": [
+                                    {"to_length": 1, "sequence": "A"}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [4],
+                    "score": -1
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 7, "offset": 1, "is_reverse": true},
+                                "edit": [
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [8],
+                    "score": 1
                 },
                 {
                     "path": {
@@ -1168,13 +1373,41 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                             {
                                 "position": {"node_id": 6, "is_reverse": true},
                                 "edit": [
-                                    {"from_length": 1, "to_length": 1, "sequence": "G"}
+                                    {"to_length": 2, "sequence": "AA"}
                                 ]
                             }
                         ]
                     },
-                    "next": [3],
-                    "score": 2
+                    "next": [6],
+                    "score": -2
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 6, "is_reverse": true},
+                                "edit": [
+                                    {"from_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [7],
+                    "score": -1
+                },
+                                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 6, "offset": 1, "is_reverse": true},
+                                "edit": [
+                                    {"to_length": 1, "sequence": "A"}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [8],
+                    "score": -1
                 },
                 {                
                     "path": {
@@ -1182,50 +1415,65 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
                             {
                                 "position": {"node_id": 5, "is_reverse": true},
                                 "edit": [
-                                    {"from_length": 1, "to_length": 1}
+                                    {"from_length": 1, "to_length": 1},
+                                    {"to_length": 2, "sequence": "AA"}
                                 ]
                             },
                         ]
                     },
-                    "score": 5
+                    "score": 1
                 }
             ],
+            "sequence": "AAAAAAA",
             "mapping_quality": 20
         }
     )";
 
     vg::MultipathAlignment alignment_2;
-    json2pb(alignment_2, alignment_2_str);
+    Utils::json2pb(alignment_2, alignment_2_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(!paths_index.index().bidirectional());
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
+    
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 3);
 
-    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", 1000);
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", 1000, 0, true, 0);
 
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-    REQUIRE(alignment_paths.size() == 3);
+    REQUIRE(alignment_paths.size() == 4);
 
     SECTION("Paired-end multipath read alignment finds alignment path(s)") {
 
-        REQUIRE(alignment_paths.front().seq_length == 10);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({1}));                
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 16);
         REQUIRE(alignment_paths.front().min_mapq == 10);
-        REQUIRE(alignment_paths.front().score_sum == 20);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.front().search_state) == vector<gbwt::size_type>({1}));                
+        REQUIRE(alignment_paths.front().score_sum == 9);
 
-        REQUIRE(alignment_paths.at(1).seq_length == 7);
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({0})); 
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == 12);
         REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
-        REQUIRE(alignment_paths.at(1).score_sum == alignment_paths.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).search_state) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths.at(1).score_sum == 1);
 
-        REQUIRE(alignment_paths.back().seq_length == alignment_paths.at(1).min_mapq);
-        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(1).min_mapq);
-        REQUIRE(alignment_paths.back().score_sum == alignment_paths.at(1).score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths.back().search_state) == vector<gbwt::size_type>({2}));                
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(2).gbwt_search) == vector<gbwt::size_type>({2}));                              
+        REQUIRE(alignment_paths.at(2).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(2).frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths.at(2).min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths.at(2).score_sum == alignment_paths.front().score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(2).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(2).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == -48651);
     }
 
     SECTION("Incorrect oriented paired-end multipath read alignment finds empty alignment path") {
 
-        auto alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_seq_length_func);
+        auto alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_frag_length_func);
+        alignment_2_rc.set_sequence("AAAAAAA");
         
         auto alignment_paths_rc = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2_rc);
         REQUIRE(alignment_paths_rc.empty());
@@ -1233,7 +1481,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Extended paired-end multipath read alignment finds alignment path(s)") {
 
-        alignment_1.mutable_subpath(2)->add_next(3);
+        alignment_1.mutable_subpath(3)->add_next(4);
 
         auto new_subpath = alignment_1.add_subpath();
         new_subpath->set_score(0);
@@ -1247,16 +1495,24 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         new_edit->set_from_length(2);
         new_edit->set_to_length(2);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "AA");
+
         auto alignment_paths_ext = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ext.size() == 2);
+        REQUIRE(alignment_paths_ext.size() == 3);
 
         REQUIRE(alignment_paths_ext.front() == alignment_paths.front());
-        REQUIRE(alignment_paths_ext.back() == alignment_paths.back());
+        REQUIRE(alignment_paths_ext.at(1) == alignment_paths.at(2));
+
+        REQUIRE(alignment_paths_ext.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ext.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ext.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ext.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ext.back().score_sum == -47877);
     }
 
     SECTION("Partial overlapping paired-end read alignment finds alignment path(s)") {
 
-        alignment_1.mutable_subpath(2)->add_next(3);
+        alignment_1.mutable_subpath(3)->add_next(4);
 
         auto new_subpath = alignment_1.add_subpath();
         new_subpath->set_score(0);
@@ -1270,61 +1526,185 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         new_edit->set_from_length(1);
         new_edit->set_to_length(1);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "A");
+
         auto alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ov.size() == 1);
+        REQUIRE(alignment_paths_ov.size() == 2);
 
         REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+
+        REQUIRE(alignment_paths_ov.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ov.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ov.back().score_sum == -737);
 
         new_edit->set_from_length(2);
         new_edit->set_to_length(2);
 
+        alignment_1.set_sequence(alignment_1.sequence() + "A");
+
         alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_ov.size() == 1);
+        REQUIRE(alignment_paths_ov.size() == 2);
 
         REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+
+        REQUIRE(alignment_paths_ov.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ov.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ov.back().score_sum == -737);
+
+        alignment_1.mutable_subpath(4)->add_next(5);
+
+        new_subpath = alignment_1.add_subpath();
+        new_subpath->set_score(0);
+
+        new_mapping = new_subpath->mutable_path()->add_mapping();
+        new_mapping->mutable_position()->set_node_id(6);
+        new_mapping->mutable_position()->set_offset(0);
+        new_mapping->mutable_position()->set_is_reverse(false);
+
+        new_edit = new_mapping->add_edit();
+        new_edit->set_from_length(1);
+        new_edit->set_to_length(1);
+
+        alignment_1.set_sequence(alignment_1.sequence() + "A");
+
+        alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_ov.size() == 2);
+
+        REQUIRE(alignment_paths_ov.front() == alignment_paths.at(1));
+
+        REQUIRE(alignment_paths_ov.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ov.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ov.back().score_sum == -737);
+
+        new_edit->set_to_length(0);
+
+        alignment_1.mutable_subpath(5)->add_next(6);
+
+        new_subpath = alignment_1.add_subpath();
+        new_subpath->set_score(0);
+
+        new_mapping = new_subpath->mutable_path()->add_mapping();
+        new_mapping->mutable_position()->set_node_id(6);
+        new_mapping->mutable_position()->set_offset(1);
+        new_mapping->mutable_position()->set_is_reverse(false);
+
+        new_edit = new_mapping->add_edit();
+        new_edit->set_to_length(1);
+
+        alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_ov.size() == 2);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov.front().gbwt_search) == vector<gbwt::size_type>({0}));   
+        REQUIRE(alignment_paths_ov.front().is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths_ov.front().frag_length == 11);
+        REQUIRE(alignment_paths_ov.front().min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths_ov.front().score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(alignment_paths_ov.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ov.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ov.back().score_sum == -737);
+
+        alignment_1.mutable_subpath(6)->add_next(7);
+
+        new_subpath = alignment_1.add_subpath();
+        new_subpath->set_score(-2);
+
+        new_mapping = new_subpath->mutable_path()->add_mapping();
+        new_mapping->mutable_position()->set_node_id(9);
+        new_mapping->mutable_position()->set_offset(0);
+        new_mapping->mutable_position()->set_is_reverse(false);
+
+        new_edit = new_mapping->add_edit();
+        new_edit->set_from_length(1);
+        new_edit->set_to_length(1);
+
+        alignment_1.set_sequence(alignment_1.sequence() + "A");
+
+        alignment_paths_ov = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_ov.size() == 2);
+
+        REQUIRE(alignment_paths_ov.front().gbwt_search == alignment_paths.at(1).gbwt_search);
+        REQUIRE(alignment_paths_ov.front().is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths_ov.front().frag_length == alignment_paths.at(1).frag_length);
+        REQUIRE(alignment_paths_ov.front().min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths_ov.front().score_sum == -1);
+
+        REQUIRE(alignment_paths_ov.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_ov.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_ov.back().score_sum == -737);
     }
 
     SECTION("Perfect overlapping paired-end multipath read alignment finds alignment path(s)") {
 
-        auto alignment_1_rc = lazy_reverse_complement_alignment(alignment_1, node_seq_length_func);
+        auto alignment_1_rc = Utils::lazy_reverse_complement_alignment(alignment_1, node_frag_length_func);
+        alignment_1_rc.set_sequence("AAAAAA");
 
         auto alignment_paths_ov_1 = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_1_rc);
-        REQUIRE(alignment_paths_ov_1.size() == 3);
+        REQUIRE(alignment_paths_ov_1.size() == 4);
 
-        REQUIRE(alignment_paths_ov_1.front().seq_length == 3);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(!alignment_paths_ov_1.front().is_multimap);
+        REQUIRE(alignment_paths_ov_1.front().frag_length == 6);
         REQUIRE(alignment_paths_ov_1.front().min_mapq == 10);
-        REQUIRE(alignment_paths_ov_1.front().score_sum == 20);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.front().search_state) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths_ov_1.front().score_sum == 12);
 
-        REQUIRE(alignment_paths_ov_1.at(1).seq_length == alignment_paths_ov_1.front().seq_length);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.at(1).gbwt_search) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths_ov_1.at(1).is_multimap == alignment_paths_ov_1.front().is_multimap);
+        REQUIRE(alignment_paths_ov_1.at(1).frag_length == alignment_paths_ov_1.front().frag_length);
         REQUIRE(alignment_paths_ov_1.at(1).min_mapq == alignment_paths_ov_1.front().min_mapq);
-        REQUIRE(alignment_paths_ov_1.at(1).score_sum == 16);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.at(1).search_state) == vector<gbwt::size_type>({1}));                
+        REQUIRE(alignment_paths_ov_1.at(1).score_sum == 6);
 
-        REQUIRE(alignment_paths_ov_1.back().seq_length == alignment_paths_ov_1.at(1).seq_length);
-        REQUIRE(alignment_paths_ov_1.back().min_mapq == alignment_paths_ov_1.at(1).min_mapq);
-        REQUIRE(alignment_paths_ov_1.back().score_sum == alignment_paths_ov_1.at(1).score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.back().search_state) == vector<gbwt::size_type>({2}));
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_1.at(2).gbwt_search) == vector<gbwt::size_type>({2}));                
+        REQUIRE(alignment_paths_ov_1.at(2).is_multimap == alignment_paths_ov_1.at(1).is_multimap);
+        REQUIRE(alignment_paths_ov_1.at(2).frag_length == alignment_paths_ov_1.at(1).frag_length);
+        REQUIRE(alignment_paths_ov_1.at(2).min_mapq == alignment_paths_ov_1.at(1).min_mapq);
+        REQUIRE(alignment_paths_ov_1.at(2).score_sum == alignment_paths_ov_1.front().score_sum);
 
-        auto alignment_2_rc = lazy_reverse_complement_alignment(alignment_2, node_seq_length_func);
+        REQUIRE(alignment_paths_ov_1.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov_1.back().is_multimap == alignment_paths_ov_1.at(2).is_multimap);
+        REQUIRE(alignment_paths_ov_1.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov_1.back().min_mapq == alignment_paths_ov_1.at(2).min_mapq);
+        REQUIRE(alignment_paths_ov_1.back().score_sum == -1030681);
+
+        auto alignment_2_rc = Utils::lazy_reverse_complement_alignment(alignment_2, node_frag_length_func);
+        alignment_2_rc.set_sequence("AAAAAAA");
 
         auto alignment_paths_ov_2 = alignment_path_finder.findPairedAlignmentPaths(alignment_2, alignment_2_rc);
-        REQUIRE(alignment_paths_ov_2.size() == 3);
+        REQUIRE(alignment_paths_ov_2.size() == 4);
 
-        REQUIRE(alignment_paths_ov_2.front().seq_length == 3);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().gbwt_search) == vector<gbwt::size_type>({1}));                
+        REQUIRE(!alignment_paths_ov_2.front().is_multimap);
+        REQUIRE(alignment_paths_ov_2.front().frag_length == 8);
         REQUIRE(alignment_paths_ov_2.front().min_mapq == 20);
-        REQUIRE(alignment_paths_ov_2.front().score_sum == 24);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.front().search_state) == vector<gbwt::size_type>({2}));                
+        REQUIRE(alignment_paths_ov_2.front().score_sum == 6);
 
-        REQUIRE(alignment_paths_ov_2.at(1).seq_length == alignment_paths_ov_2.front().seq_length);
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.at(1).gbwt_search) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths_ov_2.at(1).is_multimap == alignment_paths_ov_2.front().is_multimap);
+        REQUIRE(alignment_paths_ov_2.at(1).frag_length == 9);
         REQUIRE(alignment_paths_ov_2.at(1).min_mapq == alignment_paths_ov_2.front().min_mapq);
-        REQUIRE(alignment_paths_ov_2.at(1).score_sum == 20);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.at(1).search_state) == vector<gbwt::size_type>({0}));                
+        REQUIRE(alignment_paths_ov_2.at(1).score_sum == -4);
 
-        REQUIRE(alignment_paths_ov_2.back().seq_length == alignment_paths_ov_2.at(1).seq_length);
-        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.at(1).min_mapq);
-        REQUIRE(alignment_paths_ov_2.back().score_sum == alignment_paths_ov_2.front().score_sum);
-        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.back().search_state) == vector<gbwt::size_type>({1}));                
+        REQUIRE(paths_index.locatePathIds(alignment_paths_ov_2.at(2).gbwt_search) == vector<gbwt::size_type>({2}));                
+        REQUIRE(alignment_paths_ov_2.at(2).is_multimap == alignment_paths_ov_2.front().is_multimap);
+        REQUIRE(alignment_paths_ov_2.at(2).frag_length == alignment_paths_ov_2.front().frag_length);
+        REQUIRE(alignment_paths_ov_2.at(2).min_mapq == alignment_paths_ov_2.at(1).min_mapq);
+        REQUIRE(alignment_paths_ov_2.at(2).score_sum == alignment_paths_ov_2.front().score_sum);
+
+        REQUIRE(alignment_paths_ov_2.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_ov_2.back().is_multimap == alignment_paths_ov_2.at(2).is_multimap);
+        REQUIRE(alignment_paths_ov_2.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_ov_2.back().min_mapq == alignment_paths_ov_2.at(2).min_mapq);
+        REQUIRE(alignment_paths_ov_2.back().score_sum == -3512);
     }
 
     SECTION("Paired-end multipath read alignment finds forward alignment path(s) in bidirectional index") {
@@ -1342,55 +1722,422 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         gbwt::GBWT gbwt_index_bd;
         gbwt_index_bd.load(gbwt_stream_bd);
         
-        PathsIndex paths_index_bd(gbwt_index_bd, graph);
-        REQUIRE(paths_index_bd.index().bidirectional() == true);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
+        PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000);
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index_bd.numberOfPaths() == 2);
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", 1000, 0, true, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_bd.size() == 2);
+        REQUIRE(alignment_paths_bd.size() == 3);
 
-        REQUIRE(alignment_paths_bd.front() == alignment_paths.front());
-        REQUIRE(alignment_paths_bd.back() == alignment_paths.at(1));
-    }
+        REQUIRE(paths_index_bd.locatePathIds(alignment_paths_bd.front().gbwt_search) == vector<gbwt::size_type>({1}));
+        REQUIRE(alignment_paths_bd.front().is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths_bd.front().frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths_bd.front().min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths_bd.front().score_sum == alignment_paths.front().score_sum);
 
-    SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on length") {
-
-        alignment_path_finder.setMaxPairSeqLength(10);
-
-        auto alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.size() == 3);
-        
-        REQUIRE(alignment_paths_len == alignment_paths);
-
-        alignment_path_finder.setMaxPairSeqLength(7);
-
-        alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.size() == 1);
-        
-        REQUIRE(alignment_paths_len.front() == alignment_paths.at(1));
-
-        alignment_path_finder.setMaxPairSeqLength(6);
-
-        alignment_paths_len = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);        
-        REQUIRE(alignment_paths_len.empty());
+        REQUIRE(alignment_paths_bd.at(1) == alignment_paths.at(1));
+        REQUIRE(alignment_paths_bd.back() == alignment_paths.back());
     }
 
     SECTION("Strand-specific paired-end multipath read alignment finds unidirectional alignment path(s)") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "fr", 1000);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "fr", 1000, 0, true, 0);
 
         auto alignment_paths_fr = alignment_path_finder_fr.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_fr.size() == 2);
+        REQUIRE(alignment_paths_fr.size() == 3);
 
-        assert(alignment_paths_fr.front() == alignment_paths.front());
-        assert(alignment_paths_fr.at(1) == alignment_paths.at(1));
+        REQUIRE(alignment_paths_fr.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_fr.at(1) == alignment_paths.at(1));
+        REQUIRE(alignment_paths_fr.back() == alignment_paths.back());
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_rf(paths_index, "rf", 1000);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_rf(paths_index, "rf", 1000, 0, true, 0);
 
         auto alignment_paths_rf = alignment_path_finder_rf.findPairedAlignmentPaths(alignment_1, alignment_2);
-        REQUIRE(alignment_paths_rf.size() == 1);
+        REQUIRE(alignment_paths_rf.size() == 2);
 
-        assert(alignment_paths_rf.front() == alignment_paths.back());
+        REQUIRE(alignment_paths_rf.front() == alignment_paths.at(2));
+
+        REQUIRE(alignment_paths_rf.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_rf.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_rf.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_rf.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_rf.back().score_sum == -47829);
+    }
+
+    SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on length") {
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len16(paths_index, "unstranded", 16, 0, true, 0);
+
+        auto alignment_paths_len16 = alignment_path_finder_len16.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_len16.size() == 4);
+        
+        REQUIRE(alignment_paths_len16 == alignment_paths);
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len12(paths_index, "unstranded", 12, 0, true, 0);
+
+        auto alignment_paths_len12 = alignment_path_finder_len12.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_len12.size() == 2);
+
+        REQUIRE(alignment_paths_len12.front() == alignment_paths.at(1));
+        REQUIRE(alignment_paths_len12.back() == alignment_paths.back());
+        
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len11(paths_index, "unstranded", 11, 0, true, 0);
+
+        auto alignment_paths_len11 = alignment_path_finder_len11.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_len11.empty());
+    }
+
+    SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on best score fraction") {
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs25(paths_index, "unstranded", 1000, 0, true, 0.25);
+
+        auto alignment_paths_bs25 = alignment_path_finder_bs25.findPairedAlignmentPaths(alignment_1, alignment_2);    
+        REQUIRE(alignment_paths_bs25.size() == 4);
+
+        assert(alignment_paths_bs25 == alignment_paths);
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs30(paths_index, "unstranded", 1000, 0, true, 0.30);
+
+        auto alignment_paths_bs30 = alignment_path_finder_bs30.findPairedAlignmentPaths(alignment_1, alignment_2);    
+        REQUIRE(alignment_paths_bs30.size() == 4);
+
+        REQUIRE(alignment_paths_bs30.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_bs30.at(1)== alignment_paths.at(1));
+        REQUIRE(alignment_paths_bs30.at(2)== alignment_paths.at(2));
+
+        REQUIRE(alignment_paths_bs30.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_bs30.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_bs30.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_bs30.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_bs30.back().score_sum == 0);
+    }
+
+    SECTION("Alignment pairs from a paired-end multipath alignment does not estimate missing path noise probability") {
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", 1000, 0, false, 0);
+
+        auto alignment_paths_nm = alignment_path_finder_nm.findPairedAlignmentPaths(alignment_1, alignment_2);
+        REQUIRE(alignment_paths_nm.size() == 4);
+
+        REQUIRE(alignment_paths_nm.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_nm.at(1)== alignment_paths.at(1));
+        REQUIRE(alignment_paths_nm.at(2)== alignment_paths.at(2));
+
+        REQUIRE(alignment_paths_nm.back().gbwt_search == alignment_paths.back().gbwt_search);
+        REQUIRE(alignment_paths_nm.back().is_multimap == alignment_paths.back().is_multimap);
+        REQUIRE(alignment_paths_nm.back().frag_length == alignment_paths.back().frag_length);
+        REQUIRE(alignment_paths_nm.back().min_mapq == alignment_paths.back().min_mapq);
+        REQUIRE(alignment_paths_nm.back().score_sum ==  numeric_limits<int32_t>::lowest());
+    }  
+}
+
+TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath alignment") {
+
+    const string graph_str = R"(
+        {
+            "node": [
+                {"id": 1, "sequence": "AA"},
+                {"id": 2, "sequence": "A"},
+                {"id": 3, "sequence": "A"},
+                {"id": 4, "sequence": "A"},
+                {"id": 5, "sequence": "AAA"},
+                {"id": 6, "sequence": "AAA"},
+                {"id": 7, "sequence": "AAA"},
+                {"id": 8, "sequence": "AA"},
+                {"id": 9, "sequence": "AAA"},
+                {"id": 10, "sequence": "A"}
+            ],
+            "edge": [
+                {"from": 1, "to": 2},
+                {"from": 1, "to": 3},
+                {"from": 1, "to": 4},
+                {"from": 2, "to": 5},
+                {"from": 3, "to": 5},
+                {"from": 4, "to": 5},
+                {"from": 5, "to": 6},
+                {"from": 6, "to": 7},
+                {"from": 7, "to": 8},
+                {"from": 7, "to": 9},
+                {"from": 8, "to": 9},
+                {"from": 9, "to": 10}
+            ]
+        }
+    )";
+
+    vg::Graph graph;
+    Utils::json2pb(graph, graph_str);
+
+    gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
+    gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(10, true)));
+
+    gbwt::vector_type gbwt_thread_1(8);
+    gbwt::vector_type gbwt_thread_2(6);
+    gbwt::vector_type gbwt_thread_3(7);
+   
+    gbwt_thread_1[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_1[1] = gbwt::Node::encode(2, false);
+    gbwt_thread_1[2] = gbwt::Node::encode(5, false);
+    gbwt_thread_1[3] = gbwt::Node::encode(6, false);
+    gbwt_thread_1[4] = gbwt::Node::encode(7, false);
+    gbwt_thread_1[5] = gbwt::Node::encode(8, false);
+    gbwt_thread_1[6] = gbwt::Node::encode(9, false);
+    gbwt_thread_1[7] = gbwt::Node::encode(10, false);
+
+    gbwt_thread_2[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_2[1] = gbwt::Node::encode(3, false);
+    gbwt_thread_2[2] = gbwt::Node::encode(5, false);
+    gbwt_thread_2[3] = gbwt::Node::encode(6, false);
+    gbwt_thread_2[4] = gbwt::Node::encode(7, false);
+    gbwt_thread_2[5] = gbwt::Node::encode(9, false);
+
+    gbwt_thread_3[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_3[1] = gbwt::Node::encode(4, false);
+    gbwt_thread_3[2] = gbwt::Node::encode(5, false);
+    gbwt_thread_3[3] = gbwt::Node::encode(6, false);
+    gbwt_thread_3[4] = gbwt::Node::encode(7, false);
+    gbwt_thread_3[5] = gbwt::Node::encode(9, false);
+    gbwt_thread_3[6] = gbwt::Node::encode(10, false);
+
+    gbwt_builder.insert(gbwt_thread_1, false);
+    gbwt_builder.insert(gbwt_thread_2, false);
+    gbwt_builder.insert(gbwt_thread_3, false);
+
+    gbwt_builder.finish();
+
+    std::stringstream gbwt_stream;
+    gbwt_builder.index.serialize(gbwt_stream);
+
+    gbwt::GBWT gbwt_index;
+    gbwt_index.load(gbwt_stream);
+
+    const string alignment_1_str = R"(
+        {
+            "start": [0],
+            "subpath": [
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 1, "offset": 1},
+                                "edit": [
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [1,2],
+                    "score": 1
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 2},
+                                "edit": [
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [3],
+                    "score": 1
+                },
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 3},
+                                "edit": [
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "next": [3],
+                    "score": 1
+                },
+                {                
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 5},
+                                "edit": [
+                                    {"from_length": 3, "to_length": 3}
+                                ]
+                            },
+                            {
+                                "position": {"node_id": 6},
+                                "edit": [
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            }
+                        ]
+                    },
+                    "score": 4
+                }
+            ],
+            "sequence": "AAAAAA",
+            "mapping_quality": 10
+        }
+    )";
+
+    vg::MultipathAlignment alignment_1;
+    Utils::json2pb(alignment_1, alignment_1_str);
+
+    const string alignment_2_str = R"(
+        {
+            "start": [0],
+            "subpath": [
+                {
+                    "path": {
+                        "mapping": [
+                            {
+                                "position": {"node_id": 10, "is_reverse": true},
+                                "edit": [
+                                    {"to_length": 2, "sequence": "AA"},
+                                    {"from_length": 1, "to_length": 1}
+                                ]
+                            },
+                            {
+                                "position": {"node_id": 9, "is_reverse": true},
+                                "edit": [
+                                    {"from_length": 3, "to_length": 3}
+                                ]
+                            },
+                            {
+                                "position": {"node_id": 7, "is_reverse": true},
+                                "edit": [
+                                    {"from_length": 3, "to_length": 3},
+                                    {"to_length": 1, "sequence": "A"}
+                                ]
+                            }
+                        ]
+                    },
+                    "score": 7
+                }
+            ],
+            "sequence": "AAAAAAAAAA",
+            "mapping_quality": 20
+        }
+    )";
+
+    vg::MultipathAlignment alignment_2;
+    Utils::json2pb(alignment_2, alignment_2_str);
+
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
+    
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 3);
+
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", 1000, 4, true, 0);
+
+    auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
+    REQUIRE(alignment_paths.size() == 10);
+
+    SECTION("Paired-end multipath read alignment finds partial alignment path(s)") {
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.front().gbwt_search) == vector<gbwt::size_type>({0}));                
+        REQUIRE(!alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.front().frag_length == 19);
+        REQUIRE(alignment_paths.front().min_mapq == 10);
+        REQUIRE(alignment_paths.front().score_sum == 10);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(1).gbwt_search) == vector<gbwt::size_type>({0})); 
+        REQUIRE(alignment_paths.at(1).is_multimap == alignment_paths.front().is_multimap);
+        REQUIRE(alignment_paths.at(1).frag_length == alignment_paths.front().frag_length);
+        REQUIRE(alignment_paths.at(1).min_mapq == alignment_paths.front().min_mapq);
+        REQUIRE(alignment_paths.at(1).score_sum == 8);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(2).gbwt_search) == vector<gbwt::size_type>({2})); 
+        REQUIRE(alignment_paths.at(2).is_multimap == alignment_paths.at(1).is_multimap);
+        REQUIRE(alignment_paths.at(2).frag_length == 17);
+        REQUIRE(alignment_paths.at(2).min_mapq == alignment_paths.at(1).min_mapq);
+        REQUIRE(alignment_paths.at(2).score_sum == 11);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(3).gbwt_search) == vector<gbwt::size_type>({2})); 
+        REQUIRE(alignment_paths.at(3).is_multimap == alignment_paths.at(2).is_multimap);
+        REQUIRE(alignment_paths.at(3).frag_length == alignment_paths.at(2).frag_length);
+        REQUIRE(alignment_paths.at(3).min_mapq == alignment_paths.at(2).min_mapq);
+        REQUIRE(alignment_paths.at(3).score_sum == alignment_paths.at(1).score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(4).gbwt_search) == vector<gbwt::size_type>({1,2})); 
+        REQUIRE(alignment_paths.at(4).is_multimap == alignment_paths.at(3).is_multimap);
+        REQUIRE(alignment_paths.at(4).frag_length == alignment_paths.at(3).frag_length);
+        REQUIRE(alignment_paths.at(4).min_mapq == alignment_paths.at(3).min_mapq);
+        REQUIRE(alignment_paths.at(4).score_sum == alignment_paths.front().score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(5).gbwt_search) == vector<gbwt::size_type>({1})); 
+        REQUIRE(alignment_paths.at(5).is_multimap == alignment_paths.at(4).is_multimap);
+        REQUIRE(alignment_paths.at(5).frag_length == alignment_paths.at(4).frag_length);
+        REQUIRE(alignment_paths.at(5).min_mapq == alignment_paths.at(4).min_mapq);
+        REQUIRE(alignment_paths.at(5).score_sum == 12);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(6).gbwt_search) == vector<gbwt::size_type>({1})); 
+        REQUIRE(alignment_paths.at(6).is_multimap == alignment_paths.at(5).is_multimap);
+        REQUIRE(alignment_paths.at(6).frag_length == alignment_paths.at(5).frag_length);
+        REQUIRE(alignment_paths.at(6).min_mapq == alignment_paths.at(5).min_mapq);
+        REQUIRE(alignment_paths.at(6).score_sum == 9);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(7).gbwt_search) == vector<gbwt::size_type>({0,1,2})); 
+        REQUIRE(alignment_paths.at(7).is_multimap == alignment_paths.at(6).is_multimap);
+        REQUIRE(alignment_paths.at(7).frag_length == alignment_paths.at(6).frag_length);
+        REQUIRE(alignment_paths.at(7).min_mapq == alignment_paths.at(6).min_mapq);
+        REQUIRE(alignment_paths.at(7).score_sum == 7);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.at(8).gbwt_search) == vector<gbwt::size_type>({0})); 
+        REQUIRE(alignment_paths.at(8).is_multimap == alignment_paths.at(7).is_multimap);
+        REQUIRE(alignment_paths.at(8).frag_length == alignment_paths.at(7).frag_length);
+        REQUIRE(alignment_paths.at(8).min_mapq == alignment_paths.at(7).min_mapq);
+        REQUIRE(alignment_paths.at(8).score_sum == alignment_paths.at(6).score_sum);
+
+        REQUIRE(paths_index.locatePathIds(alignment_paths.back().gbwt_search).empty());
+        REQUIRE(alignment_paths.back().is_multimap == alignment_paths.at(8).is_multimap);
+        REQUIRE(alignment_paths.back().frag_length == 0);
+        REQUIRE(alignment_paths.back().min_mapq == alignment_paths.at(8).min_mapq);
+        REQUIRE(alignment_paths.back().score_sum == numeric_limits<int32_t>::lowest());
+    }
+
+    SECTION("Partial alignment pairs from a paired-end multipath alignment are filtered based on maximum internal offset") {
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int3(paths_index, "unstranded", 1000, 3, true, 0);
+
+        auto alignment_paths_int3 = alignment_path_finder_int3.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_int3.size() == 7);
+        
+        REQUIRE(alignment_paths_int3.front() == alignment_paths.front());
+        REQUIRE(alignment_paths_int3.at(1) == alignment_paths.at(1));
+        REQUIRE(alignment_paths_int3.at(2) == alignment_paths.at(2));
+        REQUIRE(alignment_paths_int3.at(3) == alignment_paths.at(3));
+        REQUIRE(alignment_paths_int3.at(4) == alignment_paths.at(4));
+        REQUIRE(alignment_paths_int3.at(5) == alignment_paths.at(5));
+        REQUIRE(alignment_paths_int3.back() == alignment_paths.back());
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int2(paths_index, "unstranded", 1000, 2, true, 0);
+
+        auto alignment_paths_int2 = alignment_path_finder_int2.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_int2.size() == 4);
+
+        REQUIRE(alignment_paths_int2.front() == alignment_paths.at(2));
+        REQUIRE(alignment_paths_int2.at(1) == alignment_paths.at(4));
+        REQUIRE(alignment_paths_int2.at(2) == alignment_paths.at(5));
+        REQUIRE(alignment_paths_int2.back() == alignment_paths.back());
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int1(paths_index, "unstranded", 1000, 1, true, 0);
+
+        auto alignment_paths_int1 = alignment_path_finder_int1.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_int1.size() == 2);
+
+        REQUIRE(alignment_paths_int1.front() == alignment_paths.at(5));
+        REQUIRE(alignment_paths_int1.back() == alignment_paths.back());
+
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int0(paths_index, "unstranded", 1000, 0, true, 0);
+
+        auto alignment_paths_int0 = alignment_path_finder_int0.findPairedAlignmentPaths(alignment_1, alignment_2);        
+        REQUIRE(alignment_paths_int0.empty());        
     }
 }

--- a/src/tests/alignment_path_test.cpp
+++ b/src/tests/alignment_path_test.cpp
@@ -7,28 +7,75 @@
 #include "../utils.hpp"
 
 
-TEST_CASE("Empty AlignmentSearchPath is not complete") {
-    
-	AlignmentSearchPath alignment_search_path;
-	REQUIRE(alignment_search_path.complete() == false);
-}
-
 TEST_CASE("AlignmentPath can be created from AlignmentSearchPath") {
     
 	AlignmentSearchPath alignment_search_path;
-
-	alignment_search_path.seq_length = 100;
-	alignment_search_path.min_mapq = 10;
+	alignment_search_path.insert_length = 100;
 	
-	alignment_search_path.scores.push_back(50);
-	alignment_search_path.scores.push_back(60);
+	alignment_search_path.read_align_stats.emplace_back(AlignmentStats());
+	alignment_search_path.read_align_stats.back().mapq = 10;
+	alignment_search_path.read_align_stats.back().score = 50;
+	alignment_search_path.read_align_stats.back().length = 100;
+	alignment_search_path.read_align_stats.back().left_softclip_length = 10;
+	alignment_search_path.read_align_stats.back().right_softclip_length = 30;
+
+	alignment_search_path.read_align_stats.back().internal_start.is_internal = true;
+	alignment_search_path.read_align_stats.back().internal_start.penalty = 10;
+	alignment_search_path.read_align_stats.back().internal_start.offset = 10;
+
+	alignment_search_path.read_align_stats.back().internal_end.is_internal = true;
+	alignment_search_path.read_align_stats.back().internal_end.penalty = 15;
+	alignment_search_path.read_align_stats.back().internal_end.offset = 20;
+
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetLeftBases() == 20);
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetRightBases() == 50);
+
+	REQUIRE(alignment_search_path.read_align_stats.back().adjustedScore() == 25);
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetTotalBases() == 70);
+
+	alignment_search_path.read_align_stats.emplace_back(AlignmentStats());
+	alignment_search_path.read_align_stats.back().mapq = 20;
+	alignment_search_path.read_align_stats.back().score = 7;
+	alignment_search_path.read_align_stats.back().length = 10;
+	alignment_search_path.read_align_stats.back().left_softclip_length = 2;
+	alignment_search_path.read_align_stats.back().right_softclip_length = 0;
+
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetLeftBases() == 2);
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetRightBases() == 0);
+
+	REQUIRE(alignment_search_path.read_align_stats.back().adjustedScore() == 7);
+	REQUIRE(alignment_search_path.read_align_stats.back().clippedOffsetTotalBases() == 2);
+
+	REQUIRE(Utils::doubleCompare(alignment_search_path.fragmentLength(), 158));
+	REQUIRE(Utils::doubleCompare(alignment_search_path.minMappingQuality(), 10));
+	REQUIRE(Utils::doubleCompare(alignment_search_path.scoreSum(), 32));
+
+	REQUIRE(Utils::doubleCompare(alignment_search_path.minOptimalScoreFraction(vector<int32_t>({100, 10})), 0.25));
+	REQUIRE(Utils::doubleCompare(alignment_search_path.maxSoftclipFraction(), 0.4));
 
 	AlignmentPath alignment_path(alignment_search_path, false);
 	
-	REQUIRE(alignment_path.seq_length == 100);
+	REQUIRE(alignment_path.frag_length == 158);
 	REQUIRE(alignment_path.min_mapq == 10);
-	REQUIRE(alignment_path.score_sum == 110);
-	REQUIRE(alignment_path.search_state.empty());
+	REQUIRE(alignment_path.score_sum == 32);
+	REQUIRE(alignment_path.gbwt_search.first.empty());
+
+    SECTION("Insert length can be negative for overlapping paired-end alignments") {
+
+    	alignment_search_path.insert_length = -8;
+		AlignmentPath alignment_path_neg(alignment_search_path, false);
+	
+		REQUIRE(alignment_path_neg.frag_length == 50);
+		REQUIRE(alignment_path_neg.min_mapq == alignment_path.min_mapq);
+		REQUIRE(alignment_path_neg.score_sum == alignment_path.score_sum);
+		REQUIRE(alignment_path_neg.gbwt_search == alignment_path.gbwt_search);
+    }
+
+    SECTION("Cleared AlignmentPath is empty") {
+
+    	alignment_search_path.clear();
+
+		REQUIRE(alignment_search_path.path.empty());    	
+		REQUIRE(alignment_search_path.gbwt_search.first.empty());    	
+    }    
 }
-
-

--- a/src/tests/fragment_length_dist_test.cpp
+++ b/src/tests/fragment_length_dist_test.cpp
@@ -12,10 +12,10 @@ TEST_CASE("FragmentLengthDist is valid normal distribution") {
     REQUIRE(fragment_length_dist.isValid());	
     REQUIRE(fragment_length_dist.maxLength() == 20);
 
-    REQUIRE(doubleCompare(fragment_length_dist.logProb(9), -1.737085713764618));
-    REQUIRE(doubleCompare(fragment_length_dist.logProb(15), -4.737085713764618));
-    REQUIRE(doubleCompare(fragment_length_dist.logProb(9), fragment_length_dist.logProb(11)));
-    REQUIRE(doubleCompare(fragment_length_dist.logProb(10000), -12475014.11208571307361));
+    REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(9), -1.737085713764618));
+    REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(15), -4.737085713764618));
+    REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(9), fragment_length_dist.logProb(11)));
+    REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(10000), -12475014.11208571307361));
 
 }
 
@@ -32,7 +32,7 @@ TEST_CASE("Fragment length distribution parameters can be parsed from vg::Alignm
 	    )";
 
 	    vg::Alignment alignment;
-	    json2pb(alignment, alignment_str);
+	    Utils::json2pb(alignment, alignment_str);
 
 	    REQUIRE(!fragment_length_dist.parseAlignment(alignment));	
 	}
@@ -46,7 +46,7 @@ TEST_CASE("Fragment length distribution parameters can be parsed from vg::Alignm
 	    )";
 
 	    vg::Alignment alignment;
-	    json2pb(alignment, alignment_str);
+	    Utils::json2pb(alignment, alignment_str);
 
 	    REQUIRE(!fragment_length_dist.parseAlignment(alignment));	
 	}
@@ -60,11 +60,11 @@ TEST_CASE("Fragment length distribution parameters can be parsed from vg::Alignm
 	    )";
 
 	    vg::Alignment alignment;
-	    json2pb(alignment, alignment_str);
+	    Utils::json2pb(alignment, alignment_str);
 
 	    REQUIRE(fragment_length_dist.parseAlignment(alignment));
-	    REQUIRE(doubleCompare(fragment_length_dist.mean(), 10));
-	    REQUIRE(doubleCompare(fragment_length_dist.sd(), 2));
+	    REQUIRE(Utils::doubleCompare(fragment_length_dist.mean(), 10));
+	    REQUIRE(Utils::doubleCompare(fragment_length_dist.sd(), 2));
 	}
 }
 
@@ -81,7 +81,7 @@ TEST_CASE("Fragment length distribution parameters can be parsed from vg::Multip
 	    )";
 
 	    vg::MultipathAlignment alignment;
-	    json2pb(alignment, alignment_str);
+	    Utils::json2pb(alignment, alignment_str);
 
 	    REQUIRE(!fragment_length_dist.parseMultipathAlignment(alignment));	
 	}
@@ -95,11 +95,11 @@ TEST_CASE("Fragment length distribution parameters can be parsed from vg::Multip
 	    )";
 
 	    vg::MultipathAlignment alignment;
-	    json2pb(alignment, alignment_str);
+	    Utils::json2pb(alignment, alignment_str);
 
 	    REQUIRE(fragment_length_dist.parseMultipathAlignment(alignment));
-	    REQUIRE(doubleCompare(fragment_length_dist.mean(), 10));
-	    REQUIRE(doubleCompare(fragment_length_dist.sd(), 2));
+	    REQUIRE(Utils::doubleCompare(fragment_length_dist.mean(), 10));
+	    REQUIRE(Utils::doubleCompare(fragment_length_dist.sd(), 2));
 	}
 }
 

--- a/src/tests/path_abundance_estimator_test.cpp
+++ b/src/tests/path_abundance_estimator_test.cpp
@@ -9,13 +9,13 @@ TEST_CASE("Weighted minimum path cover can be found") {
     
     auto path_abundance_estimator = MinimumPathAbundanceEstimator(1, 1, 1, 1, 1);
 
-    Eigen::ColMatrixXb read_path_cover(4, 3);
+    Utils::ColMatrixXb read_path_cover(4, 3);
 	read_path_cover << 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1;
 
-	Eigen::RowVectorXui read_counts(1, 4);
+	Utils::RowVectorXui read_counts(1, 4);
 	read_counts << 1, 3, 1, 5;
 
-	Eigen::RowVectorXd path_weights(1, 3);
+	Utils::RowVectorXd path_weights(1, 3);
 	path_weights << 1, 1, 1;
 
 	REQUIRE(path_abundance_estimator.weightedMinimumPathCover(read_path_cover, read_counts, path_weights) == vector<uint32_t>({0, 1}));

--- a/src/tests/path_clusters_test.cpp
+++ b/src/tests/path_clusters_test.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "gbwt/dynamic_gbwt.h"
+#include "gbwt/fast_locate.h"
 #include "sparsepp/spp.h"
 
 #include "../path_clusters.hpp"
@@ -65,15 +66,17 @@ TEST_CASE("GBWT paths can be clustered") {
     )";
 
 	vg::Graph graph;
-	json2pb(graph, graph_str);
+	Utils::json2pb(graph, graph_str);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(paths_index.index().metadata.paths() == 4);
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
+
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 4);
 
     spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> align_paths_index;
-    spp::sparse_hash_map<gbwt::SearchState, uint32_t> search_to_path_index;
 
-    PathClusters path_clusters(1, paths_index, align_paths_index, &search_to_path_index);
+    PathClusters path_clusters(1, paths_index, align_paths_index);
     path_clusters.addNodeClusters(paths_index);
 
     REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
@@ -83,37 +86,38 @@ TEST_CASE("GBWT paths can be clustered") {
     REQUIRE(path_clusters.cluster_to_paths_index.at(1) == vector<uint32_t>({1, 3}));
     REQUIRE(path_clusters.cluster_to_paths_index.at(2) == vector<uint32_t>({2}));
 
-    REQUIRE(search_to_path_index.empty());    
-
     SECTION("Bidirectionality affect clustering") {
 
     	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
-	    gbwt::GBWTBuilder gbwt_builder_bidi(gbwt::bit_length(gbwt::Node::encode(7, true)));
+	    gbwt::GBWTBuilder gbwt_builder_bd(gbwt::bit_length(gbwt::Node::encode(7, true)));
 
-	    gbwt_builder_bidi.insert(gbwt_thread_1, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_2, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_3, true);
-	    gbwt_builder_bidi.insert(gbwt_thread_4, true);
+	    gbwt_builder_bd.insert(gbwt_thread_1, true);
+	    gbwt_builder_bd.insert(gbwt_thread_2, true);
+	    gbwt_builder_bd.insert(gbwt_thread_3, true);
+	    gbwt_builder_bd.insert(gbwt_thread_4, true);
 
-	    gbwt_builder_bidi.index.addMetadata();
+	    gbwt_builder_bd.index.addMetadata();
 
 	    for (uint32_t i = 0; i < 4; ++i) {
 
-	    	gbwt_builder_bidi.index.metadata.addPath(gbwt::PathName());
+	    	gbwt_builder_bd.index.metadata.addPath(gbwt::PathName());
 	    }    
 
-	    gbwt_builder_bidi.finish();
+	    gbwt_builder_bd.finish();
 
-	    std::stringstream gbwt_stream_bidi;
-	    gbwt_builder_bidi.index.serialize(gbwt_stream_bidi);
+	    std::stringstream gbwt_stream_bd;
+	    gbwt_builder_bd.index.serialize(gbwt_stream_bd);
 
-	    gbwt::GBWT gbwt_index_bidi;
-	    gbwt_index_bidi.load(gbwt_stream_bidi);
+	    gbwt::GBWT gbwt_index_bd;
+	    gbwt_index_bd.load(gbwt_stream_bd);
 
-	    PathsIndex paths_index_bidi(gbwt_index_bidi, graph);
-	    REQUIRE(paths_index_bidi.index().metadata.paths() == 4);
+        gbwt::FastLocate r_index_bd(gbwt_index_bd);
+	    PathsIndex paths_index_bd(gbwt_index_bd, r_index_bd, graph);
 
-    	path_clusters.addNodeClusters(paths_index_bidi);
+        REQUIRE(paths_index_bd.bidirectional());
+        REQUIRE(paths_index.numberOfPaths() == 4);
+
+    	path_clusters.addNodeClusters(paths_index_bd);
 
 	    REQUIRE(path_clusters.path_to_cluster_index.size() == 4);
 	    REQUIRE(path_clusters.path_to_cluster_index == vector<uint32_t>({0, 0, 1, 0}));

--- a/src/tests/paths_index_test.cpp
+++ b/src/tests/paths_index_test.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "gbwt/dynamic_gbwt.h"
+#include "gbwt/fast_locate.h"
 
 #include "../paths_index.hpp"
 #include "../utils.hpp"
@@ -27,7 +28,7 @@ TEST_CASE("Path index can calculate path lengths") {
     )";
 
 	vg::Graph graph;
-	json2pb(graph, graph_str);
+	Utils::json2pb(graph, graph_str);
 
 	gbwt::Verbosity::set(gbwt::Verbosity::SILENT);
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(4, true)));
@@ -54,8 +55,11 @@ TEST_CASE("Path index can calculate path lengths") {
     gbwt::GBWT gbwt_index;
     gbwt_index.load(gbwt_stream);
 
-    PathsIndex paths_index(gbwt_index, graph);
-    REQUIRE(paths_index.index().bidirectional() == false);
+    gbwt::FastLocate r_index(gbwt_index);
+    PathsIndex paths_index(gbwt_index, r_index, graph);
+
+    REQUIRE(!paths_index.bidirectional());
+    REQUIRE(paths_index.numberOfPaths() == 2);
 
     REQUIRE(paths_index.pathLength(0) == 38);
     REQUIRE(paths_index.pathLength(1) == 7);
@@ -64,13 +68,13 @@ TEST_CASE("Path index can calculate path lengths") {
 
 		FragmentLengthDist fragment_length_dist(5, 2);
 
-    	REQUIRE(doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 32.889504274642021));
-    	REQUIRE(doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 2.4592743581826583));
+    	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 32.889504274642021));
+    	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 2.4592743581826583));
 
     	fragment_length_dist = FragmentLengthDist(20, 1);
 
-    	REQUIRE(doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 18));
-    	REQUIRE(doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 1));
+    	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 18));
+    	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 1));
 	}
 }
 

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -11,45 +11,50 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 	spp::sparse_hash_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+	vector<AlignmentPath> alignment_paths;
+	alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), false, 10, 10, 3);
+	alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), false, 10, 10, numeric_limits<int32_t>::lowest());
+	
+	vector<vector<gbwt::size_type> > alignment_path_ids;
+	alignment_path_ids.emplace_back(vector<gbwt::size_type>({100, 200}));
+	alignment_path_ids.emplace_back(vector<gbwt::size_type>());
 
 	vector<PathInfo> paths(2, PathInfo(""));
 	paths.front().effective_length = 3;
 	paths.back().effective_length = 3;
 
 	ReadPathProbabilities read_path_probs(1, pow(10, -8));
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+	read_path_probs.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 	REQUIRE(read_path_probs.readCount() == 1);
-	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-	REQUIRE(read_path_probs.probabilities().size() == 2);
+	REQUIRE(Utils::doubleCompare(read_path_probs.noiseProb(), 0.1));
 
-	REQUIRE(read_path_probs.probabilities().front().first == 0);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().front().second, 0.45));
-	REQUIRE(read_path_probs.probabilities().back().first == 1);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().back().second, 0.45));
+	REQUIRE(read_path_probs.pathProbs().size() == 1);
+	REQUIRE(Utils::doubleCompare(read_path_probs.pathProbs().front().first, 0.45));
+	REQUIRE(read_path_probs.pathProbs().front().second == vector<uint32_t>({0, 1}));
 
-    SECTION("Improbable alignment path returns finite probabilities") {
+    SECTION("Improbable alignment path returns finite path probabilities") {
 
-    	alignment_paths.front().seq_length = 100000;
+    	alignment_paths.front().frag_length = 100000;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
-		REQUIRE(doubleCompare(read_path_probs_2.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_2.probabilities().size() == 2);
+		REQUIRE(read_path_probs_2.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.1));
 
-		REQUIRE(read_path_probs.probabilities().front().first == read_path_probs_2.probabilities().front().first);
-		REQUIRE(read_path_probs.probabilities().front().second - read_path_probs_2.probabilities().front().second < pow(10, -8));
-		REQUIRE(read_path_probs.probabilities().back().first == read_path_probs_2.probabilities().back().first);
-		REQUIRE(read_path_probs.probabilities().back().second - read_path_probs_2.probabilities().back().second < pow(10, -8));
+		REQUIRE(read_path_probs_2.pathProbs().size() == 1);
+		REQUIRE(abs(read_path_probs_2.pathProbs().front().first - read_path_probs.pathProbs().front().first) < pow(10, -8));
+		REQUIRE(read_path_probs_2.pathProbs().front().second == read_path_probs.pathProbs().front().second);
 	}
 
     SECTION("Probabilities are calculated from multiple alignment paths") {
 
-		alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
-		alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
+		alignment_paths.at(1) = AlignmentPath(make_pair(gbwt::SearchState(), 0), false, 15, 10, 5);
+		alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), false, 10, 10, numeric_limits<int32_t>::lowest());
+
+		alignment_path_ids.at(1) = vector<gbwt::size_type>({50});
+		alignment_path_ids.emplace_back(vector<gbwt::size_type>());
 		
 		clustered_path_index.emplace(10, 2);
 		clustered_path_index.emplace(50, 3);
@@ -60,36 +65,89 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 		paths.emplace_back(PathInfo(""));
 		paths.back().effective_length = 3;
 
-		ReadPathProbabilities read_path_probs_3(1, pow(10, -8));
-		read_path_probs_3.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
+		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
-		REQUIRE(read_path_probs_3.readCount() == 1);
-		REQUIRE(doubleCompare(read_path_probs_3.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_3.probabilities().size() == 3);
+		REQUIRE(read_path_probs_2.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.1));
+		
+		REQUIRE(read_path_probs_2.pathProbs().size() == 2);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().front().first, 0.233044027062125));
+		REQUIRE(read_path_probs_2.pathProbs().front().second == vector<uint32_t>({3}));
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().back().first, 0.333477986468937));
+		REQUIRE(read_path_probs_2.pathProbs().back().second == vector<uint32_t>({0, 1}));
 
-		REQUIRE(read_path_probs_3.probabilities().at(0).first == 0);
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(0).second, 0.333477986468937));
-		REQUIRE(read_path_probs_3.probabilities().at(1).first == 1);
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(1).second, 0.333477986468937));
-		REQUIRE(read_path_probs_3.probabilities().at(2).first == 3);
-		REQUIRE(doubleCompare(read_path_probs_3.probabilities().at(2).second, 0.233044027062125));
+		SECTION("Probability precision affect number of unique path probabilities") {
+
+			paths.back().effective_length = 2;
+
+			ReadPathProbabilities read_path_probs_3(1, 0.1);
+			read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+
+			REQUIRE(read_path_probs_3.readCount() == 1);
+			REQUIRE(Utils::doubleCompare(read_path_probs_3.noiseProb(), 0.1));
+
+			REQUIRE(read_path_probs_3.pathProbs().size() == 1);
+			REQUIRE(Utils::doubleCompare(read_path_probs_3.pathProbs().front().first, 0.3));
+			REQUIRE(read_path_probs_3.pathProbs().front().second == vector<uint32_t>({0, 1, 3}));
+		}
 	}
 
-    SECTION("Effective path lengths affect probabilities") {
+   SECTION("Noise alignment path affect noise probability affect") {
+
+   		alignment_paths.back().score_sum = -2.302585 / Utils::noise_score_log_base;
+
+		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
+		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+
+		REQUIRE(read_path_probs_2.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.190000008369464));
+
+		REQUIRE(read_path_probs_2.pathProbs().size() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().front().first, 0.404999995815267));
+		REQUIRE(read_path_probs_2.pathProbs().front().second == vector<uint32_t>({0, 1}));
+
+		alignment_paths.back().score_sum = 0;
+
+		ReadPathProbabilities read_path_probs_3(1, pow(10, -8));
+		read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+
+		REQUIRE(read_path_probs_3.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_3.noiseProb(), 1));
+
+		REQUIRE(read_path_probs_3.pathProbs().empty());
+	}
+
+    SECTION("Effective path lengths affect path probabilities") {
 
 		paths.back().effective_length = 2;
 
-		ReadPathProbabilities read_path_probs_4(1, pow(10, -8));
-		read_path_probs_4.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
+		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
-		REQUIRE(read_path_probs_4.readCount() == 1);
-		REQUIRE(doubleCompare(read_path_probs_4.noiseProbability(), 0.1));
-		REQUIRE(read_path_probs_4.probabilities().size() == 2);
+		REQUIRE(read_path_probs_2.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.1));
 
-		REQUIRE(read_path_probs.probabilities().front().first == 0);
-		REQUIRE(doubleCompare(read_path_probs_4.probabilities().front().second, 0.359999999999999));
-		REQUIRE(read_path_probs.probabilities().back().first == 1);
-		REQUIRE(doubleCompare(read_path_probs_4.probabilities().back().second, 0.540000000000000));
+		REQUIRE(read_path_probs_2.pathProbs().size() == 2);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().front().first, 0.36));
+		REQUIRE(read_path_probs_2.pathProbs().front().second == vector<uint32_t>({0}));
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().back().first, 0.54));
+		REQUIRE(read_path_probs_2.pathProbs().back().second == vector<uint32_t>({1}));
+	}
+
+    SECTION("Base noise probability affect path probabilities") {
+
+   		alignment_paths.back().score_sum = -5.0 / Utils::noise_score_log_base;
+
+		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
+		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0.3);
+		
+		REQUIRE(read_path_probs_2.readCount() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.304716562899359));
+
+		REQUIRE(read_path_probs_2.pathProbs().size() == 1);
+		REQUIRE(Utils::doubleCompare(read_path_probs_2.pathProbs().front().first, 0.347641718550320));
+		REQUIRE(read_path_probs_2.pathProbs().front().second == read_path_probs.pathProbs().front().second);
 	}
 }
 
@@ -98,81 +156,28 @@ TEST_CASE("Identical read path probabilities can be merged") {
 	spp::sparse_hash_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
 	FragmentLengthDist fragment_length_dist(10, 2);
 
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
+	vector<AlignmentPath> alignment_paths;
+	alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), false, 10, 10, 3);
+	alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), false, 10, 10, numeric_limits<int32_t>::lowest());
+	
+	vector<vector<gbwt::size_type> > alignment_path_ids;
+	alignment_path_ids.emplace_back(vector<gbwt::size_type>({100, 200}));
+	alignment_path_ids.emplace_back(vector<gbwt::size_type>());
 
 	vector<PathInfo> paths(2, PathInfo(""));
 	paths.front().effective_length = 3;
 	paths.back().effective_length = 3;
 
 	ReadPathProbabilities read_path_probs(1, pow(10, -8));
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
+	read_path_probs.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
-	REQUIRE(read_path_probs.mergeIdenticalReadPathProbabilities(read_path_probs));
+	REQUIRE(read_path_probs.quickMergeIdentical(read_path_probs));
 
 	REQUIRE(read_path_probs.readCount() == 2);
-	REQUIRE(doubleCompare(read_path_probs.noiseProbability(), 0.1));
-	REQUIRE(read_path_probs.probabilities().size() == 2);
+	REQUIRE(Utils::doubleCompare(read_path_probs.noiseProb(), 0.1));
 
-	REQUIRE(read_path_probs.probabilities().front().first == 0);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().front().second, 0.45));
-	REQUIRE(read_path_probs.probabilities().back().first == 1);
-	REQUIRE(doubleCompare(read_path_probs.probabilities().back().second, 0.45));
-
-	SECTION("Probability precision affect merge") {
-
-		vector<PathInfo> paths(2, PathInfo(""));
-		paths.front().effective_length = 2;
-		paths.back().effective_length = 3;
-
-		ReadPathProbabilities read_path_probs_2(3, 0.1);
-		read_path_probs_2.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
-
-		REQUIRE(read_path_probs_2.mergeIdenticalReadPathProbabilities(read_path_probs));
-		REQUIRE(read_path_probs_2.readCount() == 5);
-	}
-}
-
-TEST_CASE("Read path probabilities can be collapsed") {
-
-	
-	spp::sparse_hash_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}, {10, 2}, {50, 3}});
-	FragmentLengthDist fragment_length_dist(10, 2);
-
-	vector<AlignmentPath> alignment_paths(1, AlignmentPath(10, 10, 3, false, gbwt::SearchState()));
-	alignment_paths.emplace_back(AlignmentPath(15, 10, 5, false, gbwt::SearchState()));
-
-	auto alignment_path_ids = vector<vector<gbwt::size_type> >(1, vector<gbwt::size_type>({100, 200}));
-	alignment_path_ids.emplace_back(vector<gbwt::size_type>({50}));
-
-	vector<PathInfo> paths(4, PathInfo(""));
-	paths.at(0).effective_length = 3;
-	paths.at(1).effective_length = 3;
-	paths.at(2).effective_length = 3;
-	paths.at(3).effective_length = 3;
-
-	ReadPathProbabilities read_path_probs(1, 0.01);
-	read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
-
-	auto collapsed_probs = read_path_probs.collapsedProbabilities();
-	REQUIRE(collapsed_probs.size() == 2);
-
-	REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0.233044027062125));
-	REQUIRE(doubleCompare(collapsed_probs.at(1).first, 0.333477986468937));
-
-	REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({3}));
-	REQUIRE(collapsed_probs.at(1).second == vector<uint32_t>({0, 1}));
-
-	SECTION("Probability precision affect collapse") {
-
-		ReadPathProbabilities read_path_probs(1, 0.2);
-		read_path_probs.calcReadPathProbabilities(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false);
-
-		auto collapsed_probs = read_path_probs.collapsedProbabilities();
-		REQUIRE(collapsed_probs.size() == 1);
-
-		REQUIRE(doubleCompare(collapsed_probs.at(0).first, 0.333477986468937));
-		REQUIRE(collapsed_probs.at(0).second == vector<uint32_t>({0, 1, 3}));
-	}
+	REQUIRE(read_path_probs.pathProbs().size() == 1);
+	REQUIRE(Utils::doubleCompare(read_path_probs.pathProbs().front().first, 0.45));
+	REQUIRE(read_path_probs.pathProbs().front().second == vector<uint32_t>({0, 1}));
 }
 

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -37,38 +37,11 @@ void ThreadedOutputWriter::write() {
 
 ProbabilityClusterWriter::ProbabilityClusterWriter(const string filename_prefix, const uint32_t num_threads, const double prob_precision_in) : ThreadedOutputWriter(filename_prefix + "_probs.txt.gz", "wg", num_threads), prob_precision(prob_precision_in), prob_precision_digits(ceil(-1 * log10(prob_precision))) {}
 
-void ProbabilityClusterWriter::addCollapsedProbabilities(stringstream * out_sstream, const ReadPathProbabilities & read_path_probs) {
-
-    *out_sstream << read_path_probs.readCount() << " " << read_path_probs.noiseProbability();
-
-    for (auto & collapsed_probs: read_path_probs.collapsedProbabilities()) {
-
-        *out_sstream << " " << collapsed_probs.first << ":";
-
-        bool is_first = true;
-
-        for (auto idx: collapsed_probs.second) {
-
-            if (is_first) {
-
-                *out_sstream << idx;
-                is_first = false;
-
-            } else {
-
-                *out_sstream << "," << idx;
-            }
-        }
-    }
-
-    *out_sstream << endl;
-}
-
-void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & cluster_probs, const vector<PathInfo> & cluster_paths) {
+void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & read_path_cluster_probs, const vector<PathInfo> & cluster_paths) {
 
     assert(!cluster_paths.empty());
 
-    if (!cluster_probs.empty()) {
+    if (!read_path_cluster_probs.empty()) {
 
         auto out_sstream = new stringstream;
 
@@ -83,14 +56,35 @@ void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & 
 
         *out_sstream << endl;
 
-        if (!cluster_probs.empty()) {
+        if (!read_path_cluster_probs.empty()) {
 
             *out_sstream << setprecision(prob_precision_digits);
 
-            for (auto & probs: cluster_probs) {
+            for (auto & read_path_probs: read_path_cluster_probs) {
 
-                assert(probs.probabilities().size() <= cluster_paths.size());
-                addCollapsedProbabilities(out_sstream, probs);
+                *out_sstream << read_path_probs.readCount() << " " << read_path_probs.noiseProb();
+
+                for (auto & path_probs: read_path_probs.pathProbs()) {
+
+                    *out_sstream << " " << path_probs.first << ":";
+
+                    bool is_first = true;
+
+                    for (auto path: path_probs.second) {
+
+                        if (is_first) {
+
+                            *out_sstream << path;
+                            is_first = false;
+
+                        } else {
+
+                            *out_sstream << "," << path;
+                        }
+                    }
+                }
+
+                *out_sstream << endl;
             }
         }
 

--- a/src/threaded_output_writer.hpp
+++ b/src/threaded_output_writer.hpp
@@ -44,14 +44,12 @@ class ProbabilityClusterWriter : public ThreadedOutputWriter {
         ProbabilityClusterWriter(const string filename_prefix, const uint32_t num_threads, const double prob_precision_in);
         ~ProbabilityClusterWriter() {};
 
-        void addCluster(const vector<ReadPathProbabilities> & cluster_probs, const vector<PathInfo> & cluster_paths);
+        void addCluster(const vector<ReadPathProbabilities> & read_path_cluster_probs, const vector<PathInfo> & cluster_paths);
 
     private:
 
         const double prob_precision;
         const uint32_t prob_precision_digits;
-
-        void addCollapsedProbabilities(stringstream * prob_out_sstream, const ReadPathProbabilities & probs);
 };
 
 class GibbsSamplesWriter : public ThreadedOutputWriter {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -21,291 +21,11 @@
 using namespace std;
 
 
-namespace Eigen {
+template<class T, class T2>
+inline ostream & operator<<(ostream & os, const pair<T,T2> & values) {
 
-    typedef Eigen::Matrix<uint32_t, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXui;
-    typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXd;
-
-    typedef Eigen::Matrix<uint32_t, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXui;
-    typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXd;
-    
-    typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;
-    typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXd;
-
-    typedef Eigen::SparseMatrix<bool, Eigen::ColMajor> ColSparseMatrixXb;
-    typedef Eigen::SparseMatrix<double, Eigen::ColMajor> ColSparseMatrixXd;
-}
-
-//------------------------------------------------------------------------------
-
-/*
-The following code have been copied and modified from https://github.com/vgteam/vg
-*/
-
-// Convert integer Phred quality score to probability of wrongness.
-inline double phred_to_prob(uint32_t phred) {
-    return pow(10, -((double)phred) / 10);
-}
-
-// Convert probability of wrongness to integer Phred quality score.
-inline double prob_to_phred(double prob) {
-    return -10.0 * log10(prob);
-}
-
-// log normal pdf, from http://stackoverflow.com/a/10848293/238609
-template <typename T>
-inline T log_normal_pdf(T x, T m, T s)
-{
-    static const T inv_sqrt_2pi = 0.3989422804014327;
-    T a = (x - m) / s;
-
-    return log(inv_sqrt_2pi) - log(s) - T(0.5) * a * a;
-}
-
-/*
- * Return the log of the sum of two log-transformed values without taking them
- * out of log space.
- */
-inline double add_log(double log_x, double log_y) {
-    return log_x > log_y ? log_x + log1p(exp(log_y - log_x)) : log_y + log1p(exp(log_x - log_y));
-}
-
-/// Convert vg::Mapping to gbwt::node_type.
-inline gbwt::node_type mapping_to_gbwt(const vg::Mapping & mapping) {
-    return gbwt::Node::encode(mapping.position().node_id(), mapping.position().is_reverse());
-}
-
-inline uint32_t mapping_to_length(const vg::Mapping & m) {
-    uint32_t l = 0;
-    for (uint32_t i = 0; i < m.edit_size(); ++i) {
-        const vg::Edit& e = m.edit(i);
-        l += e.to_length();
-    }
-    return l;
-}
-
-inline uint32_t mapping_from_length(const vg::Mapping & m) {
-    uint32_t l = 0;
-    for (uint32_t i = 0; i < m.edit_size(); ++i) {
-        const vg::Edit& e = m.edit(i);
-        l += e.from_length();
-    }
-    return l;
-
-}
-
-// Note that edit sequences are not reverse complemented.
-// Original function in vg repo: reverse_complement_mapping().
-inline vg::Mapping lazy_reverse_complement_mapping(const vg::Mapping& mapping,
-                                   const function<int64_t(int64_t)> & node_length) {
-    // Make a new reversed mapping
-    vg::Mapping mapping_rc;
-    *mapping_rc.mutable_position() = mapping.position();
-
-    // switching around to the reverse strand requires us to change offsets
-    // that are nonzero to count the unused bases on the other side of the block
-    // of used bases.
-    if(mapping.has_position() && mapping.position().node_id() != 0) {
-        vg::Position* p = mapping_rc.mutable_position();
-        
-        // How many node bases are used by the mapping?
-        size_t used_bases = mapping_from_length(mapping);
-        // How many are taken up by the offset on the other strand?
-        size_t unused_bases_after = p->offset();
-        // The remainder ought to be taken up by the offset on this strand.
-        size_t unused_bases_before = node_length(p->node_id()) - used_bases - unused_bases_after;
-            
-        // Adopt the new offset
-        p->set_offset(unused_bases_before);
-        // Toggle the reversed-ness flag
-        p->set_is_reverse(!p->is_reverse());
-    }
-
-    for (int64_t i = mapping.edit_size() - 1; i >= 0; i--) {
-        // For each edit in reverse order, put it in reverse complemented
-        *mapping_rc.add_edit() = mapping.edit(i);
-    }
-
-    return mapping_rc;
-}
-
-// Reverse complements path. Note that edit sequences are not reverse complemented. 
-// Original function in vg repo: reverse_complement_path().
-inline vg::Path lazy_reverse_complement_path(const vg::Path& path,
-                             const function<int64_t(int64_t)> & node_length) {
-
-    vg::Path path_rc;
-
-    for(int64_t i = path.mapping_size() - 1; i >= 0; i--) {
-        // For each mapping in reverse order, put it in reverse complemented and
-        // measured from the other end of the node.
-        *path_rc.add_mapping() = lazy_reverse_complement_mapping(path.mapping(i), node_length);
-    }
-
-    return path_rc;
-}
-
-// Reverse complements alignment. Note that sequences, paths and edit sequences 
-// are not reverse complemented. Original function in vg repo: reverse_complement_alignment().
-inline vg::Alignment lazy_reverse_complement_alignment(const vg::Alignment& aln,
-                                       const function<int64_t(int64_t)>& node_length) {
-    // We're going to reverse the alignment and all its mappings.
-    // TODO: should we/can we do this in place?
-    
-    vg::Alignment aln_rc;
-
-    aln_rc.set_sequence(aln.sequence());
-    aln_rc.set_score(aln.score());
-    aln_rc.set_mapping_quality(aln.mapping_quality());
-
-    *aln_rc.mutable_path() = lazy_reverse_complement_path(aln.path(), node_length);
-    
-    return aln_rc;
-}
-
-
-// Reverse complements multipath alignment. Note that sequences, paths and edit sequences 
-// are not reverse complemented. Original name in vg repo: rev_comp_multipath_alignment().
-inline vg::MultipathAlignment lazy_reverse_complement_alignment(const vg::MultipathAlignment& multipath_aln, const function<int64_t(int64_t)>& node_length) {
-    
-    vg::MultipathAlignment multipath_aln_rc;
-
-    multipath_aln_rc.set_sequence(multipath_aln.sequence());
-    multipath_aln_rc.set_mapping_quality(multipath_aln.mapping_quality());
-
-    vector<vector<size_t> > reverse_edge_lists(multipath_aln.subpath_size());
-    vector<vector<pair<size_t, int32_t> > > reverse_connection_lists(multipath_aln.subpath_size());
-
-    vector<size_t> reverse_starts;
-    
-    // remove subpaths to avoid duplicating
-    // multipath_aln_rc.clear_subpath();
-    
-    // add subpaths in reverse order to maintain topological ordering
-    for (int64_t i = multipath_aln.subpath_size() - 1; i >= 0; i--) {
-        const vg::Subpath& subpath = multipath_aln.subpath(i);
-        vg::Subpath* rc_subpath = multipath_aln_rc.add_subpath();
-        
-        *(rc_subpath->mutable_path()) = lazy_reverse_complement_path(subpath.path(), node_length);
-        rc_subpath->set_score(subpath.score());
-
-        if (subpath.next_size() > 0 || subpath.connection_size() > 0) {
-            // collect edges by their target (for reversing)
-            for (size_t j = 0; j < subpath.next_size(); j++) {
-                reverse_edge_lists[subpath.next(j)].push_back(i);
-            }
-            for (auto & connection: subpath.connection()) {
-                reverse_connection_lists[connection.next()].emplace_back(i, connection.score());
-            }
-        }
-        else {
-            // sink subpaths become sources in reverse
-            reverse_starts.push_back(i);
-        }
-    }
-    
-    // add reversed edges
-    for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
-        vg::Subpath* rc_subpath = multipath_aln_rc.mutable_subpath(i);
-        vector<size_t>& reverse_edge_list = reverse_edge_lists[multipath_aln.subpath_size() - i - 1];
-        for (size_t j = 0; j < reverse_edge_list.size(); j++) {
-            rc_subpath->add_next(multipath_aln.subpath_size() - reverse_edge_list[j] - 1);
-        }
-        vector<pair<size_t, int32_t> >& reverse_connection_list = reverse_connection_lists[multipath_aln.subpath_size() - i - 1];
-        for (size_t j = 0; j < reverse_connection_list.size(); ++j) {
-            vg::Connection* connection = rc_subpath->add_connection();
-            connection->set_next(multipath_aln.subpath_size() - reverse_connection_list[j].first - 1);
-            connection->set_score(reverse_connection_list[j].second);
-        }
-    }
-    
-    // remove start nodes that are invalid in reverse
-    // multipath_aln_rc.clear_start();
-    
-    // assume that if the original multipath alignment had its starts labeled they want them
-    // labeled in the reverse complement too
-    if (multipath_aln.start_size() > 0) {
-        for (size_t i = 0; i < reverse_starts.size(); i++) {
-            multipath_aln_rc.add_start(multipath_aln.subpath_size() - reverse_starts[i] - 1);
-        }
-    }
-
-    return multipath_aln_rc;
-}
-
-inline string pb2json(const google::protobuf::Message &msg) {
-
-	string buffer;
-    auto status = google::protobuf::util::MessageToJsonString(msg, &buffer);
-    
-    if (!status.ok()) {
-        throw runtime_error("Could not serialize " + msg.GetTypeName() + ": " + status.ToString());
-    }
-    
-    return buffer;
-}
-
-inline void json2pb(google::protobuf::Message &msg, const string& buf) {
-    auto status = google::protobuf::util::JsonStringToMessage(buf, &msg);
-    
-    if (!status.ok()) {
-        // This generally will happen if someone feeds in the wrong type of JSON.
-        // TODO: It would be nice to be able to find the neme of the offending non-existent field.
-        throw runtime_error("Could not deserialize " + msg.GetTypeName() + ": " + status.ToString());
-    }
-}
-
-
-//------------------------------------------------------------------------------
-
-
-inline vector<string> splitString(const string & str, const char delim) {
-
-    stringstream ss(str);
-    vector<string> elems;
-
-    for (string item; getline(ss, item, delim);) {
-
-        elems.push_back(item);
-    }
-
-    return elems;
-}
-
-// Precision used when comparing double variables.
-static const double double_precision = numeric_limits<double>::epsilon() * 100;
-
-// Compare double variables using above precision.
-inline bool doubleCompare(const double a, const double b) {
-
-    assert(isfinite(a));
-    assert(isfinite(b));
-
-    return ((a == b) or (abs(a - b) < abs(min(a, b)) * double_precision));
-}
-
-inline uint32_t numPermutations(vector<uint32_t> values) {
-
-    assert(!values.empty());
-
-    if (values.size() == 1) {
-
-        return 1;
-    }
-
-    sort(values.begin(), values.end());
-
-    uint32_t num_unique_values = 1;
-
-    for (size_t i = 1; i < values.size(); ++i) {
-
-        if (values.at(i - 1) != values.at(i)) {
-
-            num_unique_values++;
-        }
-    }
-
-    return (tgamma(values.size() + 1) / tgamma(values.size() - num_unique_values + 2));
+    os << "(" << values.first << "," << values.second << ")";
+    return os;
 }
 
 template<class T>
@@ -328,6 +48,409 @@ inline ostream & operator<<(ostream & os, const vector<T> & values) {
     }
 
     return os;
+}
+
+namespace Utils {
+
+    typedef Eigen::Matrix<uint32_t, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXui;
+    typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXd;
+
+    typedef Eigen::Matrix<uint32_t, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXui;
+    typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXd;
+    
+    typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;
+    typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXd;
+
+    typedef Eigen::SparseMatrix<bool, Eigen::ColMajor> ColSparseMatrixXb;
+    typedef Eigen::SparseMatrix<double, Eigen::ColMajor> ColSparseMatrixXd;
+
+    inline vector<string> splitString(const string & str, const char delim) {
+
+        stringstream ss(str);
+        vector<string> elems;
+
+        for (string item; getline(ss, item, delim);) {
+
+            elems.push_back(item);
+        }
+
+        return elems;
+    }
+
+    // Precision used when comparing double variables.
+    static const double double_precision = numeric_limits<double>::epsilon() * 100;
+
+    static const double score_log_base = 1.383325268738;
+    static const double noise_score_log_base = 1e-6;
+
+    // Compare double variables using above precision.
+    inline bool doubleCompare(const double a, const double b) {
+
+        assert(isfinite(a));
+        assert(isfinite(b));
+
+        return ((a == b) or (abs(a - b) < abs(min(a, b)) * double_precision));
+    }
+
+    inline uint32_t numPermutations(vector<uint32_t> values) {
+
+        assert(!values.empty());
+
+        if (values.size() == 1) {
+
+            return 1;
+        }
+
+        sort(values.begin(), values.end());
+
+        uint32_t num_unique_values = 1;
+
+        for (size_t i = 1; i < values.size(); ++i) {
+
+            if (values.at(i - 1) != values.at(i)) {
+
+                num_unique_values++;
+            }
+        }
+
+        return (tgamma(values.size() + 1) / tgamma(values.size() - num_unique_values + 2));
+    }
+
+    inline int32_t doubleToInt(const double value) {
+
+        return round(min(static_cast<double>(numeric_limits<int32_t>::max()), max(static_cast<double>(numeric_limits<int32_t>::lowest()), value)));
+    }
+
+    //------------------------------------------------------------------------------
+
+    /*
+    All the following code have been copied and modified from https://github.com/vgteam/vg
+    */
+
+    // Convert integer Phred quality score to probability of wrongness.
+    inline double phred_to_prob(uint32_t phred) {
+        return pow(10, -((double)phred) / 10);
+    }
+
+    // Convert probability of wrongness to integer Phred quality score.
+    inline double prob_to_phred(double prob) {
+        return -10.0 * log10(prob);
+    }
+
+    // log normal pdf, from http://stackoverflow.com/a/10848293/238609
+    template <typename T>
+    inline T log_normal_pdf(T x, T m, T s)
+    {
+        static const T inv_sqrt_2pi = 0.3989422804014327;
+        T a = (x - m) / s;
+
+        return log(inv_sqrt_2pi) - log(s) - T(0.5) * a * a;
+    }
+
+    /*
+     * Return the log of the sum of two log-transformed values without taking them
+     * out of log space.
+     */
+    inline double add_log(double log_x, double log_y) {
+        return log_x > log_y ? log_x + log1p(exp(log_y - log_x)) : log_y + log1p(exp(log_x - log_y));
+    }
+
+    /// Convert vg::Mapping to gbwt::node_type.
+    inline gbwt::node_type mapping_to_gbwt(const vg::Mapping & mapping) {
+        return gbwt::Node::encode(mapping.position().node_id(), mapping.position().is_reverse());
+    }
+
+    inline uint32_t mapping_to_length(const vg::Mapping & m) {
+        uint32_t l = 0;
+        for (uint32_t i = 0; i < m.edit_size(); ++i) {
+            const vg::Edit& e = m.edit(i);
+            l += e.to_length();
+        }
+        return l;
+    }
+
+    inline uint32_t mapping_from_length(const vg::Mapping & m) {
+        uint32_t l = 0;
+        for (uint32_t i = 0; i < m.edit_size(); ++i) {
+            const vg::Edit& e = m.edit(i);
+            l += e.from_length();
+        }
+        return l;
+    }
+
+    inline char quality_short_to_char(short i) {
+        return static_cast<char>(i + 33);
+    }
+
+    inline string string_quality_short_to_char(const string& quality) {
+        string buffer; buffer.resize(quality.size());
+        for (int i = 0; i < quality.size(); ++i) {
+            buffer[i] = quality_short_to_char(quality[i]);
+        }
+        return buffer;
+    }
+
+    // Note that edit sequences are not reverse complemented.
+    // Original function in vg repo: reverse_complement_mapping().
+    inline vg::Mapping lazy_reverse_complement_mapping(const vg::Mapping& mapping,
+                                       const function<int64_t(int64_t)> & node_length) {
+        // Make a new reversed mapping
+        vg::Mapping mapping_rc;
+        *mapping_rc.mutable_position() = mapping.position();
+
+        // switching around to the reverse strand requires us to change offsets
+        // that are nonzero to count the unused bases on the other side of the block
+        // of used bases.
+        if(mapping.has_position() && mapping.position().node_id() != 0) {
+            vg::Position* p = mapping_rc.mutable_position();
+            
+            // How many node bases are used by the mapping?
+            size_t used_bases = mapping_from_length(mapping);
+            // How many are taken up by the offset on the other strand?
+            size_t unused_bases_after = p->offset();
+            // The remainder ought to be taken up by the offset on this strand.
+            size_t unused_bases_before = node_length(p->node_id()) - used_bases - unused_bases_after;
+                
+            // Adopt the new offset
+            p->set_offset(unused_bases_before);
+            // Toggle the reversed-ness flag
+            p->set_is_reverse(!p->is_reverse());
+        }
+
+        for (int64_t i = mapping.edit_size() - 1; i >= 0; i--) {
+            // For each edit in reverse order, put it in reverse complemented
+            *mapping_rc.add_edit() = mapping.edit(i);
+        }
+
+        return mapping_rc;
+    }
+
+    // Reverse complements path. Note that edit sequences are not reverse complemented. 
+    // Original function in vg repo: reverse_complement_path().
+    inline vg::Path lazy_reverse_complement_path(const vg::Path& path,
+                                 const function<int64_t(int64_t)> & node_length) {
+
+        vg::Path path_rc;
+
+        for(int64_t i = path.mapping_size() - 1; i >= 0; i--) {
+            // For each mapping in reverse order, put it in reverse complemented and
+            // measured from the other end of the node.
+            *path_rc.add_mapping() = lazy_reverse_complement_mapping(path.mapping(i), node_length);
+        }
+
+        return path_rc;
+    }
+
+    // Reverse complements alignment. Note that sequences, paths and edit sequences 
+    // are not reverse complemented. Original function in vg repo: reverse_complement_alignment().
+    inline vg::Alignment lazy_reverse_complement_alignment(const vg::Alignment& aln,
+                                           const function<int64_t(int64_t)>& node_length) {
+        // We're going to reverse the alignment and all its mappings.
+        // TODO: should we/can we do this in place?
+        
+        vg::Alignment aln_rc;
+
+        aln_rc.set_sequence(string(aln.sequence().rbegin(), aln.sequence().rend()));
+        aln_rc.set_quality(string(aln.quality().rbegin(), aln.quality().rend()));
+
+        aln_rc.set_score(aln.score());
+        aln_rc.set_mapping_quality(aln.mapping_quality());
+
+        *aln_rc.mutable_path() = lazy_reverse_complement_path(aln.path(), node_length);
+        
+        return aln_rc;
+    }
+
+    // Reverse complements multipath alignment. Note that sequences, paths and edit sequences 
+    // are not reverse complemented. Original name in vg repo: rev_comp_multipath_alignment().
+    inline vg::MultipathAlignment lazy_reverse_complement_alignment(const vg::MultipathAlignment& multipath_aln, const function<int64_t(int64_t)>& node_length) {
+        
+        vg::MultipathAlignment multipath_aln_rc;
+
+        multipath_aln_rc.set_sequence(string(multipath_aln.sequence().rbegin(), multipath_aln.sequence().rend()));
+        multipath_aln_rc.set_quality(string(multipath_aln.quality().rbegin(), multipath_aln.quality().rend()));
+
+        multipath_aln_rc.set_mapping_quality(multipath_aln.mapping_quality());
+
+        vector<vector<size_t> > reverse_edge_lists(multipath_aln.subpath_size());
+        vector<vector<pair<size_t, int32_t> > > reverse_connection_lists(multipath_aln.subpath_size());
+
+        vector<size_t> reverse_starts;
+        
+        // remove subpaths to avoid duplicating
+        // multipath_aln_rc.clear_subpath();
+        
+        // add subpaths in reverse order to maintain topological ordering
+        for (int64_t i = multipath_aln.subpath_size() - 1; i >= 0; i--) {
+            const vg::Subpath& subpath = multipath_aln.subpath(i);
+            vg::Subpath* rc_subpath = multipath_aln_rc.add_subpath();
+            
+            *(rc_subpath->mutable_path()) = lazy_reverse_complement_path(subpath.path(), node_length);
+            rc_subpath->set_score(subpath.score());
+
+            if (subpath.next_size() > 0 || subpath.connection_size() > 0) {
+                // collect edges by their target (for reversing)
+                for (size_t j = 0; j < subpath.next_size(); j++) {
+                    reverse_edge_lists[subpath.next(j)].push_back(i);
+                }
+                for (auto & connection: subpath.connection()) {
+                    reverse_connection_lists[connection.next()].emplace_back(i, connection.score());
+                }
+            }
+            else {
+                // sink subpaths become sources in reverse
+                reverse_starts.push_back(i);
+            }
+        }
+        
+        // add reversed edges
+        for (size_t i = 0; i < multipath_aln.subpath_size(); i++) {
+            vg::Subpath* rc_subpath = multipath_aln_rc.mutable_subpath(i);
+            vector<size_t>& reverse_edge_list = reverse_edge_lists[multipath_aln.subpath_size() - i - 1];
+            for (size_t j = 0; j < reverse_edge_list.size(); j++) {
+                rc_subpath->add_next(multipath_aln.subpath_size() - reverse_edge_list[j] - 1);
+            }
+            vector<pair<size_t, int32_t> >& reverse_connection_list = reverse_connection_lists[multipath_aln.subpath_size() - i - 1];
+            for (size_t j = 0; j < reverse_connection_list.size(); ++j) {
+                vg::Connection* connection = rc_subpath->add_connection();
+                connection->set_next(multipath_aln.subpath_size() - reverse_connection_list[j].first - 1);
+                connection->set_score(reverse_connection_list[j].second);
+            }
+        }
+        
+        // remove start nodes that are invalid in reverse
+        // multipath_aln_rc.clear_start();
+        
+        // assume that if the original multipath alignment had its starts labeled they want them
+        // labeled in the reverse complement too
+        if (multipath_aln.start_size() > 0) {
+            for (size_t i = 0; i < reverse_starts.size(); i++) {
+                multipath_aln_rc.add_start(multipath_aln.subpath_size() - reverse_starts[i] - 1);
+            }
+        }
+
+        return multipath_aln_rc;
+    }
+
+    inline string pb2json(const google::protobuf::Message &msg) {
+
+    	string buffer;
+        auto status = google::protobuf::util::MessageToJsonString(msg, &buffer);
+        
+        if (!status.ok()) {
+            throw runtime_error("Could not serialize " + msg.GetTypeName() + ": " + status.ToString());
+        }
+        
+        return buffer;
+    }
+
+    inline void json2pb(google::protobuf::Message &msg, const string& buf) {
+        auto status = google::protobuf::util::JsonStringToMessage(buf, &msg);
+        
+        if (!status.ok()) {
+            // This generally will happen if someone feeds in the wrong type of JSON.
+            // TODO: It would be nice to be able to find the neme of the offending non-existent field.
+            throw runtime_error("Could not deserialize " + msg.GetTypeName() + ": " + status.ToString());
+        }
+    }
+
+    static const int8_t default_match = 1;
+    static const int8_t default_mismatch = 4;
+    static const int8_t default_full_length_bonus = 5;
+
+    static const int8_t score_matrix[16] = {
+         default_match,    -default_mismatch, -default_mismatch, -default_mismatch,
+        -default_mismatch,  default_match,    -default_mismatch, -default_mismatch,
+        -default_mismatch, -default_mismatch,  default_match,    -default_mismatch,
+        -default_mismatch, -default_mismatch, -default_mismatch,  default_match
+    };
+
+    inline vector<int8_t> qual_adjusted_matrix(double gc_content = 0.5, uint32_t max_qual = 255) {
+        
+        // TODO: duplicative with GSSWAligner()
+        double* nt_freqs = (double*) malloc(sizeof(double) * 4);
+        nt_freqs[0] = 0.5 * (1 - gc_content);
+        nt_freqs[1] = 0.5 * gc_content;
+        nt_freqs[2] = 0.5 * gc_content;
+        nt_freqs[3] = 0.5 * (1 - gc_content);
+        
+        // recover the emission probabilities of the align state of the HMM
+        double* align_prob = (double*) malloc(sizeof(double) * 16);
+        
+        for (int i = 0; i < 4; i++) {
+            for (int j = 0; j < 4; j++) {
+                align_prob[i * 4 + j] = (exp(score_log_base * score_matrix[i * 4 + j])
+                                         * nt_freqs[i] * nt_freqs[j]);
+            }
+        }
+        
+        // compute the sum of the emission probabilities under a base error
+        double* align_complement_prob = (double*) malloc(sizeof(double) * 16);
+        for (int i = 0; i < 4; i++) {
+            for (int j = 0; j < 4; j++) {
+                align_complement_prob[i * 4 + j] = 0.0;
+                for (int k = 0; k < 4; k++) {
+                    if (k != j) {
+                        align_complement_prob[i * 4 + j] += align_prob[i * 4 + k];
+                    }
+                }
+            }
+        }
+        
+        // quality score of random guessing
+        int lowest_meaningful_qual = ceil(-10.0 * log10(0.75));
+        
+        // compute the adjusted alignment scores for each quality level
+        vector<int8_t> qual_adj_mat(25 * (max_qual + 1));
+        for (int q = 0; q <= max_qual; q++) {
+            double err = pow(10.0, -q / 10.0);
+            for (int i = 0; i < 5; i++) {
+                for (int j = 0; j < 5; j++) {
+                    int8_t score;
+                    if (i == 4 || j == 4 || q < lowest_meaningful_qual) {
+                        score = 0;
+                    }
+                    else {
+                        score = round(log(((1.0 - err) * align_prob[i * 4 + j] + (err / 3.0) * align_complement_prob[i * 4 + j])
+                                          / (nt_freqs[i] * ((1.0 - err) * nt_freqs[j] + (err / 3.0) * (1.0 - nt_freqs[j])))) / score_log_base);
+                    }
+                    qual_adj_mat.at(q * 25 + i * 5 + j) = round(score);
+                }
+            }
+        }
+        
+        free(align_complement_prob);
+        free(align_prob);
+        free(nt_freqs);
+        
+        return qual_adj_mat;
+    }
+
+    inline vector<int8_t> qual_adjusted_bonuses(uint32_t max_qual = 255) {
+        
+        
+        double p_full_len = exp(score_log_base * default_full_length_bonus) / (1.0 + exp(score_log_base * default_full_length_bonus));
+        
+        vector<int8_t> qual_adj_bonuses(max_qual + 1);
+        
+        int lowest_meaningful_qual = ceil(-10.0 * log10(0.75));
+        // hack because i want the minimum qual value from illumina (2) to have zero score, but phred
+        // values are spaced out in a way to approximate this singularity well
+        ++lowest_meaningful_qual;
+        
+        for (int q = lowest_meaningful_qual; q <= max_qual; ++q) {
+            double err = pow(10.0, -q / 10.0);
+            double score = log(((1.0 - err * 4.0 / 3.0) * p_full_len + (err * 4.0 / 3.0) * (1.0 - p_full_len)) / (1.0 - p_full_len)) / score_log_base;
+            qual_adj_bonuses[q] = round(score);
+        }
+        
+        return qual_adj_bonuses;
+    }
+
+    static const vector<int8_t> qual_score_matrix = qual_adjusted_matrix();
+    static const vector<int8_t> qual_full_length_bonuses = qual_adjusted_bonuses();
+
+    //------------------------------------------------------------------------------
 }
 
 


### PR DESCRIPTION
Improvements:

- Added support for using the r-index together with the gbwt. The r-index makes certain queries much faster and thus the overall computation time is decreased when this is used. The r-index is automatically parsed. The name of the r-index should be the same as the GBWT index with an added *.ri* extension (e.g. *paths.gbwt.ri*). 
- Added an option to allow for partial matching at the ends of an alignment path when searching for matching GBWT paths. The maximum number of bases allowed at each end can be set using the option  `max-par-offset`. The default is 4. The score is penalised by the quality-adjusted number of removed bases. It is assumed that the default parameters of `vg map` or `vg mpmap` are used.
- Added a new filter that excludes alignments that have a score that is a fraction of 0.9 below the optimal score. The fraction can be changed using the option `filt-best-score`. The optimal alignment score is calculated using the quality sequence. It is assumed that the default parameters of `vg map` or `vg mpmap` are used.
- Added a minimum value for the noise probability. The default value is 1e-4 and can be changed using the option `min-noise-prob`. This was added since the mapping quality estimates from `vg map` and `vg mpmap` generally become less reliable above 40. 
- Changed how filtered alignments are handled. All filtered alignment are now used in the inference with a noise probability of 1. 

Changes to existing options and outputs:

- Removed mapping quality filter option (`filt-mapq-prob`). This option was removed since all filtered alignments (including ones with mapq 0) are now used in the inference.
- Removed score difference filter option (`filt-score-diff`). This option was removed since a better fraction-based scoring filter was added instead (`filt-best-score`).
- Made equivalent haplotype inference across clustered transcripts option default. Removed the option (`equal-haps`) to enable it and added a new option `ind-hap-inference` to enable the previous independent inference.

Bug fixes:

- Fixed bug where alignment paths containing the same node multiple times in a row with different offsets where not parsed correctly.
