### PR TITLE
Haplotype probability bug fix and changes to noise usage in expression estimation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -867,7 +867,7 @@ int main(int argc, char* argv[]) {
 
                     if (path_cluster_estimates.second.paths.at(i).effective_length > 0) {
 
-                        total_transcript_count += (path_cluster_estimates.second.abundances(0, i) * path_cluster_estimates.second.total_read_count / path_cluster_estimates.second.paths.at(i).effective_length);
+                        total_transcript_count += (path_cluster_estimates.second.abundances(0, i) / path_cluster_estimates.second.paths.at(i).effective_length);
                     }
                 }
             }

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -23,14 +23,22 @@ void PathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_estima
         Utils::RowVectorXui read_counts;
 
         constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_cluster_estimates->paths.size());
+        detractNoiseAndNormalizeProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts);
 
-        read_path_probs.conservativeResize(read_path_probs.rows(), read_path_probs.cols() + 1);
-        read_path_probs.col(read_path_probs.cols() - 1) = noise_probs;
+        if (read_path_probs.rows() == 0) {
 
-        path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size() + 1, 0, false);
-        path_cluster_estimates->total_read_count = read_counts.sum();
+            assert(noise_probs.rows() == 0);
+            assert(read_counts.cols() == 0);
 
-        EMAbundanceEstimator(path_cluster_estimates, read_path_probs, read_counts);
+            path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, true);
+            return;
+        }
+
+        const double total_read_count = read_counts.sum();
+        assert(total_read_count > 0);
+
+        path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, false);
+        EMAbundanceEstimator(path_cluster_estimates, read_path_probs, read_counts, total_read_count);
 
         if (num_gibbs_samples > 0) {
 
@@ -42,10 +50,10 @@ void PathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_estima
 
             gibbs_read_count_samples->back().samples = vector<vector<double> >(path_cluster_estimates->abundances.cols(), vector<double>());
 
-            gibbsReadCountSampler(path_cluster_estimates, read_path_probs, read_counts, abundance_gibbs_gamma, mt_rng);
+            gibbsReadCountSampler(path_cluster_estimates, read_path_probs, read_counts, total_read_count, abundance_gibbs_gamma, mt_rng);
         }
 
-        removeNoiseAndRenormalizeAbundances(path_cluster_estimates);
+        path_cluster_estimates->abundances *= total_read_count;
 
     } else {
 
@@ -53,9 +61,7 @@ void PathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster_estima
     }
 }
 
-void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts) const {
-
-    assert(path_cluster_estimates->total_read_count > 0);
+void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count) const {
 
     Utils::RowVectorXd prev_abundances = path_cluster_estimates->abundances;
     uint32_t em_conv_its = 0;
@@ -66,7 +72,7 @@ void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cl
         read_posteriors = read_posteriors.array().colwise() / read_posteriors.rowwise().sum().array();
 
         path_cluster_estimates->abundances = read_counts.cast<double>() * read_posteriors;
-        path_cluster_estimates->abundances /= path_cluster_estimates->total_read_count;
+        path_cluster_estimates->abundances /= total_read_count;
 
         bool has_converged = true;
 
@@ -119,9 +125,7 @@ void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cl
     }
 }
 
-void PathAbundanceEstimator::gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const {
-
-    assert(path_cluster_estimates->total_read_count > 0);
+void PathAbundanceEstimator::gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count, const double gamma, mt19937 * mt_rng) const {
 
     assert(!path_cluster_estimates->gibbs_read_count_samples.empty());
     assert(path_cluster_estimates->gibbs_read_count_samples.back().path_ids.size() == path_cluster_estimates->abundances.cols());
@@ -186,59 +190,22 @@ void PathAbundanceEstimator::gibbsReadCountSampler(PathClusterEstimates * path_c
 
             for (size_t i = 0; i < gibbs_abundances.cols(); ++i) {
 
-                path_cluster_estimates->gibbs_read_count_samples.back().samples.at(i).emplace_back(gibbs_abundances(0, i) * path_cluster_estimates->total_read_count);
+                path_cluster_estimates->gibbs_read_count_samples.back().samples.at(i).emplace_back(gibbs_abundances(0, i) * total_read_count);
             }
         }
     }
 }
 
-void PathAbundanceEstimator::removeNoiseAndRenormalizeAbundances(PathClusterEstimates * path_cluster_estimates) const {
-
-    const double noise_read_count = path_cluster_estimates->abundances(0, path_cluster_estimates->abundances.cols() - 1) * path_cluster_estimates->total_read_count;
-    assert(noise_read_count <= path_cluster_estimates->total_read_count);
-
-    path_cluster_estimates->posteriors.conservativeResize(1, path_cluster_estimates->posteriors.cols() - 1);
-    path_cluster_estimates->abundances.conservativeResize(1, path_cluster_estimates->abundances.cols() - 1);
-
-    assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->paths.size());
-    assert(path_cluster_estimates->abundances.cols() == path_cluster_estimates->paths.size());
-
-    const double abundances_sum = path_cluster_estimates->abundances.sum();
-    
-    if (abundances_sum > 0) {
-
-        path_cluster_estimates->abundances = path_cluster_estimates->abundances / abundances_sum;
-    } 
-
-    path_cluster_estimates->total_read_count -= noise_read_count;
-
-    for (auto & abundance_samples: path_cluster_estimates->gibbs_read_count_samples) {
-
-        assert(abundance_samples.path_ids.size() <= path_cluster_estimates->paths.size() + 1);
-        assert(abundance_samples.samples.size() <= path_cluster_estimates->paths.size() + 1);
-        
-        assert(abundance_samples.path_ids.back() == path_cluster_estimates->paths.size());
-
-        abundance_samples.path_ids.pop_back();
-        abundance_samples.samples.pop_back();
-    }
-}
-
 void PathAbundanceEstimator::updateEstimates(PathClusterEstimates * path_cluster_estimates, const PathClusterEstimates & new_path_cluster_estimates, const vector<uint32_t> & path_indices, const uint32_t sample_count) const {
 
-    assert(new_path_cluster_estimates.posteriors.cols() == path_indices.size() + 1);
-    assert(new_path_cluster_estimates.abundances.cols() == path_indices.size() + 1);
-
-    assert(path_cluster_estimates->total_read_count == new_path_cluster_estimates.total_read_count);
+    assert(new_path_cluster_estimates.posteriors.cols() == path_indices.size());
+    assert(new_path_cluster_estimates.abundances.cols() == path_indices.size());
 
    for (size_t i = 0; i < path_indices.size(); ++i) {
 
         path_cluster_estimates->posteriors(0, path_indices.at(i)) += (new_path_cluster_estimates.posteriors(0, i) * sample_count);            
         path_cluster_estimates->abundances(0, path_indices.at(i)) += (new_path_cluster_estimates.abundances(0, i) * sample_count);
     }
-
-    path_cluster_estimates->posteriors(0, path_cluster_estimates->posteriors.cols() - 1) += (new_path_cluster_estimates.posteriors(0, path_indices.size()) * sample_count);            
-    path_cluster_estimates->abundances(0, path_cluster_estimates->abundances.cols() - 1) += (new_path_cluster_estimates.abundances(0, path_indices.size()) * sample_count);  
 
     if (!new_path_cluster_estimates.gibbs_read_count_samples.empty()) {
 
@@ -291,38 +258,45 @@ void MinimumPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster
             Utils::ColVectorXd min_path_noise_probs;
             Utils::RowVectorXui min_path_read_counts;
 
-            constructPartialProbabilityMatrix(&min_path_read_path_probs, &min_path_noise_probs, &min_path_read_counts, cluster_probs, min_path_cover, path_cluster_estimates->paths.size());
+            constructPartialProbabilityMatrix(&min_path_read_path_probs, &min_path_noise_probs, &min_path_read_counts, cluster_probs, min_path_cover, path_cluster_estimates->paths.size(), true);
+            detractNoiseAndNormalizeProbabilityMatrix(&min_path_read_path_probs, &min_path_noise_probs, &min_path_read_counts);
 
-            addNoiseAndNormalizeProbabilityMatrix(&min_path_read_path_probs, min_path_noise_probs);
-            assert(min_path_read_path_probs.cols() >= 2);
+            if (min_path_read_path_probs.rows() == 0) {
 
+                assert(min_path_noise_probs.rows() == 0);
+                assert(min_path_read_counts.cols() == 0);
+
+                path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, true);
+                return;
+            }
+
+            assert(min_path_read_path_probs.cols() >= 1);
             readCollapseProbabilityMatrix(&min_path_read_path_probs, &min_path_read_counts);
+
+            const double total_min_path_read_counts = min_path_read_counts.sum();
+            assert(total_min_path_read_counts > 0);
 
             PathClusterEstimates min_path_cluster_estimates;
             min_path_cluster_estimates.initEstimates(min_path_read_path_probs.cols(), 0, false);
-            min_path_cluster_estimates.total_read_count = min_path_read_counts.sum();
 
-            EMAbundanceEstimator(&min_path_cluster_estimates, min_path_read_path_probs, min_path_read_counts);
-            assert(min_path_cluster_estimates.abundances.cols() == min_path_cover.size() + 1);            
+            EMAbundanceEstimator(&min_path_cluster_estimates, min_path_read_path_probs, min_path_read_counts, total_min_path_read_counts);
+            assert(min_path_cluster_estimates.abundances.cols() == min_path_cover.size());            
 
-            path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size() + 1, 0, true);
-            path_cluster_estimates->total_read_count = min_path_cluster_estimates.total_read_count;
+            path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, true);
 
             if (num_gibbs_samples > 0) {
 
                 vector<CountSamples> * gibbs_read_count_samples = &(min_path_cluster_estimates.gibbs_read_count_samples);
                 gibbs_read_count_samples->emplace_back(CountSamples());
 
-                gibbs_read_count_samples->back().path_ids = min_path_cover;
-                gibbs_read_count_samples->back().path_ids.emplace_back(path_cluster_estimates->abundances.cols() - 1);
-                
+                gibbs_read_count_samples->back().path_ids = min_path_cover;                
                 gibbs_read_count_samples->back().samples = vector<vector<double> >(min_path_cluster_estimates.abundances.cols(), vector<double>());
 
-                gibbsReadCountSampler(&min_path_cluster_estimates, min_path_read_path_probs, min_path_read_counts, abundance_gibbs_gamma, mt_rng);
+                gibbsReadCountSampler(&min_path_cluster_estimates, min_path_read_path_probs, min_path_read_counts, total_min_path_read_counts, abundance_gibbs_gamma, mt_rng);
             }
 
+            min_path_cluster_estimates.abundances *= total_min_path_read_counts;
             updateEstimates(path_cluster_estimates, min_path_cluster_estimates, min_path_cover, 1);    
-            removeNoiseAndRenormalizeAbundances(path_cluster_estimates);
 
         } else {
 
@@ -371,7 +345,7 @@ vector<uint32_t> MinimumPathAbundanceEstimator::weightedMinimumPathCover(const U
         assert(max_weighted_read_path_cover_idx >= 0);
 
         min_path_cover.emplace_back(max_weighted_read_path_cover_idx);
-        uncovered_read_counts = (uncovered_read_counts.array() * (!read_path_cover.col(max_weighted_read_path_cover_idx).transpose().array()).cast<uint32_t>()).matrix();
+        uncovered_read_counts = (uncovered_read_counts.array() * (!read_path_cover.col(max_weighted_read_path_cover_idx).transpose().array()).cast<double>()).matrix();
     }
 
     assert(min_path_cover.size() <= read_path_cover.cols());
@@ -414,7 +388,7 @@ void NestedPathAbundanceEstimator::inferAbundancesIndependentGroups(PathClusterE
             Utils::ColVectorXd group_noise_probs;
             Utils::RowVectorXui group_read_counts;        
 
-            constructPartialProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group, path_cluster_estimates->paths.size());
+            constructPartialProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group, path_cluster_estimates->paths.size(), true);
 
             addNoiseAndNormalizeProbabilityMatrix(&group_read_path_probs, group_noise_probs);
             readCollapseProbabilityMatrix(&group_read_path_probs, &group_read_counts);
@@ -666,12 +640,7 @@ void NestedPathAbundanceEstimator::samplePathSubsetIndices(spp::sparse_hash_map<
 
 void NestedPathAbundanceEstimator::inferPathSubsetAbundance(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng, const spp::sparse_hash_map<vector<uint32_t>, uint32_t> & path_subset_samples) const {
 
-    path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size() + 1, 0, true);
-
-    for (auto & cluster_prob: cluster_probs) {
-
-        path_cluster_estimates->total_read_count += cluster_prob.readCount();
-    }
+    path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, true);
 
     for (auto & path_subset: path_subset_samples) {
 
@@ -682,36 +651,45 @@ void NestedPathAbundanceEstimator::inferPathSubsetAbundance(PathClusterEstimates
         Utils::ColVectorXd subset_noise_probs;
         Utils::RowVectorXui subset_read_counts;
 
-        constructPartialProbabilityMatrix(&subset_read_path_probs, &subset_noise_probs, &subset_read_counts, cluster_probs, path_subset.first, path_cluster_estimates->paths.size());
+        constructPartialProbabilityMatrix(&subset_read_path_probs, &subset_noise_probs, &subset_read_counts, cluster_probs, path_subset.first, path_cluster_estimates->paths.size(), true);
+        detractNoiseAndNormalizeProbabilityMatrix(&subset_read_path_probs, &subset_noise_probs, &subset_read_counts);
 
-        addNoiseAndNormalizeProbabilityMatrix(&subset_read_path_probs, subset_noise_probs);
-        assert(subset_read_path_probs.cols() >= 2);
+        if (subset_read_path_probs.rows() == 0) {
 
+            assert(subset_noise_probs.rows() == 0);
+            assert(subset_read_counts.cols() == 0);
+
+            path_cluster_estimates->initEstimates(path_cluster_estimates->paths.size(), 0, true);
+            return;
+        }
+
+        assert(subset_read_path_probs.cols() >= 1);
         readCollapseProbabilityMatrix(&subset_read_path_probs, &subset_read_counts);
+
+        const double total_subset_read_counts = subset_read_counts.sum();
+        assert(total_subset_read_counts > 0);
 
         PathClusterEstimates subset_path_cluster_estimates;
         subset_path_cluster_estimates.initEstimates(subset_read_path_probs.cols(), 0, false);
-        subset_path_cluster_estimates.total_read_count = subset_read_counts.sum();
-       
-        EMAbundanceEstimator(&subset_path_cluster_estimates, subset_read_path_probs, subset_read_counts);
-        assert(subset_path_cluster_estimates.abundances.cols() == path_subset.first.size() + 1);            
+
+        EMAbundanceEstimator(&subset_path_cluster_estimates, subset_read_path_probs, subset_read_counts, total_subset_read_counts);
+        assert(subset_path_cluster_estimates.abundances.cols() == path_subset.first.size());            
 
         if (num_gibbs_samples > 0) {
 
             vector<CountSamples> * gibbs_read_count_samples = &(subset_path_cluster_estimates.gibbs_read_count_samples);
             gibbs_read_count_samples->emplace_back(CountSamples());
 
-            gibbs_read_count_samples->back().path_ids = path_subset.first;
-            gibbs_read_count_samples->back().path_ids.emplace_back(path_cluster_estimates->abundances.cols() - 1);
-            
+            gibbs_read_count_samples->back().path_ids = path_subset.first;            
             gibbs_read_count_samples->back().samples = vector<vector<double> >(subset_path_cluster_estimates.abundances.cols(), vector<double>());
 
             for (uint32_t i = 0; i < path_subset.second; ++i) {
 
-                gibbsReadCountSampler(&subset_path_cluster_estimates, subset_read_path_probs, subset_read_counts, abundance_gibbs_gamma, mt_rng);
+                gibbsReadCountSampler(&subset_path_cluster_estimates, subset_read_path_probs, subset_read_counts, total_subset_read_counts, abundance_gibbs_gamma, mt_rng);
             }
         }
 
+        subset_path_cluster_estimates.abundances *= total_subset_read_counts;
         updateEstimates(path_cluster_estimates, subset_path_cluster_estimates, path_subset.first, path_subset.second);
     }
 
@@ -720,7 +698,5 @@ void NestedPathAbundanceEstimator::inferPathSubsetAbundance(PathClusterEstimates
         path_cluster_estimates->abundances(0, i) /= num_subset_samples;
         path_cluster_estimates->posteriors(0, i) /= num_subset_samples;
     }
-
-    removeNoiseAndRenormalizeAbundances(path_cluster_estimates);
 }
 

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -416,9 +416,7 @@ void NestedPathAbundanceEstimator::inferAbundancesIndependentGroups(PathClusterE
 
             constructPartialProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group, path_cluster_estimates->paths.size());
 
-            group_read_path_probs.conservativeResize(group_read_path_probs.rows(), group_read_path_probs.cols() + 1);
-            group_read_path_probs.col(group_read_path_probs.cols() - 1) = group_noise_probs;
-
+            addNoiseAndNormalizeProbabilityMatrix(&group_read_path_probs, group_noise_probs);
             readCollapseProbabilityMatrix(&group_read_path_probs, &group_read_counts);
 
             group_noise_probs = group_read_path_probs.col(group_read_path_probs.cols() - 1);

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -388,7 +388,7 @@ void NestedPathAbundanceEstimator::inferAbundancesIndependentGroups(PathClusterE
             Utils::ColVectorXd group_noise_probs;
             Utils::RowVectorXd group_read_counts;        
 
-            constructPartialProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group, path_cluster_estimates->paths.size(), true);
+            constructPartialProbabilityMatrix(&group_read_path_probs, &group_noise_probs, &group_read_counts, cluster_probs, group, path_cluster_estimates->paths.size(), false);
 
             addNoiseAndNormalizeProbabilityMatrix(&group_read_path_probs, group_noise_probs);
             readCollapseProbabilityMatrix(&group_read_path_probs, &group_read_counts);

--- a/src/path_abundance_estimator.hpp
+++ b/src/path_abundance_estimator.hpp
@@ -33,9 +33,8 @@ class PathAbundanceEstimator : public PathEstimator {
         const uint32_t num_gibbs_samples;
         const uint32_t gibbs_thin_its;
 
-        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts) const;
-        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double gamma, mt19937 * mt_rng) const;
-        void removeNoiseAndRenormalizeAbundances(PathClusterEstimates * path_cluster_estimates) const;    
+        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count) const;
+        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count, const double gamma, mt19937 * mt_rng) const;
         void updateEstimates(PathClusterEstimates * path_cluster_estimates, const PathClusterEstimates & new_path_cluster_estimates, const vector<uint32_t> & path_indices, const uint32_t sample_count) const;
 };
 

--- a/src/path_abundance_estimator.hpp
+++ b/src/path_abundance_estimator.hpp
@@ -33,8 +33,8 @@ class PathAbundanceEstimator : public PathEstimator {
         const uint32_t num_gibbs_samples;
         const uint32_t gibbs_thin_its;
 
-        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count) const;
-        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXui & read_counts, const double total_read_count, const double gamma, mt19937 * mt_rng) const;
+        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts, const double total_read_count) const;
+        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts, const double total_read_count, const double gamma, mt19937 * mt_rng) const;
         void updateEstimates(PathClusterEstimates * path_cluster_estimates, const PathClusterEstimates & new_path_cluster_estimates, const vector<uint32_t> & path_indices, const uint32_t sample_count) const;
 };
 
@@ -47,7 +47,7 @@ class MinimumPathAbundanceEstimator : public PathAbundanceEstimator {
 
         void estimate(PathClusterEstimates * path_cluster_estimates, const vector<ReadPathProbabilities> & cluster_probs, mt19937 * mt_rng);
 
-        vector<uint32_t> weightedMinimumPathCover(const Utils::ColMatrixXb & read_path_cover, const Utils::RowVectorXui & read_counts, const Utils::RowVectorXd & path_weights) const;
+        vector<uint32_t> weightedMinimumPathCover(const Utils::ColMatrixXb & read_path_cover, const Utils::RowVectorXd & read_counts, const Utils::RowVectorXd & path_weights) const;
 };
 
 class NestedPathAbundanceEstimator : public PathAbundanceEstimator {

--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -45,7 +45,6 @@ struct PathClusterEstimates {
     Eigen::RowVectorXd posteriors;
     Eigen::RowVectorXd abundances;
 
-    double total_read_count;
     vector<CountSamples> gibbs_read_count_samples;
 
     vector<vector<uint32_t> > path_group_sets;
@@ -94,8 +93,6 @@ struct PathClusterEstimates {
             posteriors = Eigen::RowVectorXd::Constant(num_components, 1);
             abundances = Eigen::RowVectorXd::Constant(num_components, 1 / static_cast<float>(num_components));
         }
-
-        total_read_count = 0;
     }
 };
 

--- a/src/path_estimator.cpp
+++ b/src/path_estimator.cpp
@@ -54,13 +54,13 @@ bool probabilityCountColSorter(const pair<Utils::ColVectorXd, uint32_t> & lhs, c
 
 PathEstimator::PathEstimator(const double prob_precision_in) : prob_precision(prob_precision_in) {}
 
-void PathEstimator::constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const {
+void PathEstimator::constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const {
 
     assert(!cluster_probs.empty());
 
     *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), num_paths);
     *noise_probs = Utils::ColVectorXd(cluster_probs.size());
-    *read_counts = Utils::RowVectorXui(cluster_probs.size());
+    *read_counts = Utils::RowVectorXd(cluster_probs.size());
 
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
@@ -78,7 +78,7 @@ void PathEstimator::constructProbabilityMatrix(Utils::ColMatrixXd * read_path_pr
     }
 }
 
-void PathEstimator::constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const {
+void PathEstimator::constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const {
 
     assert(!cluster_probs.empty());
     assert(!path_ids.empty());
@@ -92,7 +92,7 @@ void PathEstimator::constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_
 
     *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), path_ids.size());
     *noise_probs = Utils::ColVectorXd(cluster_probs.size());
-    *read_counts = Utils::RowVectorXui(cluster_probs.size());
+    *read_counts = Utils::RowVectorXd(cluster_probs.size());
 
     uint32_t row_idx = 0;
 
@@ -133,7 +133,7 @@ void PathEstimator::constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_
     }
 }
 
-void PathEstimator::constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const {
+void PathEstimator::constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const {
 
     assert(!cluster_probs.empty());
     assert(!path_groups.empty());
@@ -152,7 +152,7 @@ void PathEstimator::constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_
 
     *read_path_probs = Utils::ColMatrixXd::Zero(cluster_probs.size(), path_groups.size());
     *noise_probs = Utils::ColVectorXd(cluster_probs.size());
-    *read_counts = Utils::RowVectorXui(cluster_probs.size());
+    *read_counts = Utils::RowVectorXd(cluster_probs.size());
 
     for (size_t i = 0; i < cluster_probs.size(); ++i) {
 
@@ -186,7 +186,7 @@ void PathEstimator::addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * r
     read_path_probs->col(read_path_probs->cols() - 1) = noise_probs;
 }
 
-void PathEstimator::detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts) const {
+void PathEstimator::detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts) const {
 
     if (read_path_probs->rows() > 0) {
 
@@ -215,7 +215,7 @@ void PathEstimator::detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd
     }
 }
 
-void PathEstimator::rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const {
+void PathEstimator::rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXd * read_counts) const {
 
     assert(read_path_probs->rows() > 0);
     assert(read_path_probs->rows() == read_counts->cols());
@@ -237,7 +237,7 @@ void PathEstimator::rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_prob
     }    
 }
 
-void PathEstimator::readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const {
+void PathEstimator::readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXd * read_counts) const {
 
     assert(read_path_probs->rows() > 0);
     assert(read_path_probs->rows() == read_counts->cols());
@@ -350,7 +350,7 @@ vector<double> PathEstimator::calcPathLogFrequences(const vector<uint32_t> & pat
     return path_log_freqs;
 }
 
-void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
+void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -379,7 +379,7 @@ void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path
             group_read_probs += (read_path_probs.col(path_idx) / static_cast<double>(group_size));
         }
 
-        path_cluster_estimates->posteriors(0, i) = read_counts.cast<double>() * group_read_probs.array().log().matrix();
+        path_cluster_estimates->posteriors(0, i) = read_counts * group_read_probs.array().log().matrix();
 
         for (auto & path_idx: path_cluster_estimates->path_group_sets.at(i)) {
             
@@ -397,7 +397,7 @@ void PathEstimator::calculatePathGroupPosteriorsFull(PathClusterEstimates * path
     }
 }
 
-void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
+void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -444,7 +444,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
         Utils::ColVectorXd group_read_probs_base = noise_probs;
         group_read_probs_base += (read_path_probs.col(first_path_idx) / static_cast<double>(group_size));
 
-        double max_log_likelihood_best = read_counts.cast<double>() * (group_read_probs_base + max_read_probs).array().log().matrix();
+        double max_log_likelihood_best = read_counts * (group_read_probs_base + max_read_probs).array().log().matrix();
         max_log_likelihood_best += path_log_freqs.at(first_path_idx) + log(2);
 
         if (max_log_likelihood_best - max_log_likelihood < max_log_likelihood_diff) {
@@ -456,7 +456,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
 
             const uint32_t second_path_idx = marginal_posteriors.at(j).second;
 
-            log_likelihoods.emplace_back(read_counts.cast<double>() * (group_read_probs_base + (read_path_probs.col(second_path_idx) / static_cast<double>(group_size))).array().log().matrix());
+            log_likelihoods.emplace_back(read_counts * (group_read_probs_base + (read_path_probs.col(second_path_idx) / static_cast<double>(group_size))).array().log().matrix());
             log_likelihoods.back() += path_log_freqs.at(first_path_idx) + path_log_freqs.at(second_path_idx) + log(Utils::numPermutations(vector<uint32_t>({first_path_idx, second_path_idx})));
 
             if (log_likelihoods.back() - max_log_likelihood < max_log_likelihood_diff) {
@@ -481,7 +481,7 @@ void PathEstimator::calculatePathGroupPosteriorsBounded(PathClusterEstimates * p
     }
 }
 
-void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const {
+void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const {
 
     assert(read_path_probs.rows() > 0);
     assert(read_path_probs.rows() == noise_probs.rows());
@@ -550,7 +550,7 @@ void PathEstimator::estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path
 
                     for (uint32_t k = 0; k < read_path_probs.cols(); ++k) {
 
-                        group_probs.emplace_back(read_counts.cast<double>() * (group_read_probs + (read_path_probs.col(k) / static_cast<double>(group_size))).array().log().matrix());
+                        group_probs.emplace_back(read_counts * (group_read_probs + (read_path_probs.col(k) / static_cast<double>(group_size))).array().log().matrix());
                         group_probs.back() += path_log_freqs.at(k);
 
                         sum_log_group_probs = Utils::add_log(sum_log_group_probs, group_probs.back());

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -26,23 +26,23 @@ class PathEstimator {
        
         const double prob_precision;
 
-        void constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
-        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const;
-        void constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
+        void constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
+        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const;
+        void constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
 
         void addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, const Utils::ColVectorXd & noise_probs) const;
-        void detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts) const;
+        void detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts) const;
 
-        void readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const;
+        void readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXd * read_counts) const;
         void pathCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const;
 
-        void calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
-        void calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
-        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXui & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const;
+        void calculatePathGroupPosteriorsFull(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
+        void calculatePathGroupPosteriorsBounded(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size) const;
+        void estimatePathGroupPosteriorsGibbs(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::ColVectorXd & noise_probs, const Utils::RowVectorXd & read_counts, const vector<uint32_t> & path_counts, const uint32_t group_size, mt19937 * mt_rng) const;
 
     private:
 
-        void rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const;
+        void rowSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXd * read_counts) const;
         void colSortProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const;
 
         vector<double> calcPathLogFrequences(const vector<uint32_t> & path_counts) const;

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -27,10 +27,11 @@ class PathEstimator {
         const double prob_precision;
 
         void constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
-        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const;
+        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const;
         void constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
 
         void addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, const Utils::ColVectorXd & noise_probs) const;
+        void detractNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXui * read_counts) const;
 
         void readCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::RowVectorXui * read_counts) const;
         void pathCollapseProbabilityMatrix(Utils::ColMatrixXd * read_path_probs) const;

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -10,7 +10,7 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
 
         Utils::ColMatrixXd read_path_probs;
         Utils::ColVectorXd noise_probs;
-        Utils::RowVectorXui read_counts;
+        Utils::RowVectorXd read_counts;
 
         constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_cluster_estimates->paths.size());
 
@@ -42,7 +42,7 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
 
         Utils::ColMatrixXd read_path_probs;
         Utils::ColVectorXd noise_probs;
-        Utils::RowVectorXui read_counts;
+        Utils::RowVectorXd read_counts;
 
         constructProbabilityMatrix(&read_path_probs, &noise_probs, &read_counts, cluster_probs, path_cluster_estimates->paths.size());
 

--- a/src/tests/path_abundance_estimator_test.cpp
+++ b/src/tests/path_abundance_estimator_test.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Weighted minimum path cover can be found") {
     Utils::ColMatrixXb read_path_cover(4, 3);
 	read_path_cover << 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1;
 
-	Utils::RowVectorXui read_counts(1, 4);
+	Utils::RowVectorXd read_counts(1, 4);
 	read_counts << 1, 3, 1, 5;
 
 	Utils::RowVectorXd path_weights(1, 3);

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -194,7 +194,7 @@ void PosteriorEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClus
 AbundanceEstimatesWriter::AbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const double total_transcript_count_in) : ThreadedOutputWriter(filename_prefix + ".txt", "wu", num_threads), total_transcript_count(total_transcript_count_in) {
 
     auto out_sstream = new stringstream;
-    *out_sstream << "Name\tClusterID\tLength\tEffectiveLength\tHaplotypeProbability\tClusterRelativeExpression\tReadCount\tTPM" << endl;
+    *out_sstream << "Name\tClusterID\tLength\tEffectiveLength\tHaplotypeProbability\tReadCount\tTPM" << endl;
     output_queue->push(out_sstream);
 }
 
@@ -210,7 +210,7 @@ void AbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClus
 
             if (cur_estimates.second.paths.at(i).effective_length > 0) {
 
-                transcript_count = cur_estimates.second.abundances(0, i) * cur_estimates.second.total_read_count / cur_estimates.second.paths.at(i).effective_length;
+                transcript_count = cur_estimates.second.abundances(0, i) / cur_estimates.second.paths.at(i).effective_length;
             }
 
             *out_sstream << cur_estimates.second.paths.at(i).name;
@@ -219,7 +219,6 @@ void AbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClus
             *out_sstream << "\t" << cur_estimates.second.paths.at(i).effective_length;
             *out_sstream << "\t" << cur_estimates.second.posteriors(0, i);
             *out_sstream << "\t" << cur_estimates.second.abundances(0, i);
-            *out_sstream << "\t" << cur_estimates.second.abundances(0, i) * cur_estimates.second.total_read_count;
             *out_sstream << "\t" << transcript_count / total_transcript_count * pow(10, 6);
             *out_sstream << endl;
         }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -52,10 +52,10 @@ inline ostream & operator<<(ostream & os, const vector<T> & values) {
 
 namespace Utils {
 
-    typedef Eigen::Matrix<uint32_t, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXui;
+    typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXui;
     typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXd;
 
-    typedef Eigen::Matrix<uint32_t, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXui;
+    typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXui;
     typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXd;
     
     typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -52,10 +52,7 @@ inline ostream & operator<<(ostream & os, const vector<T> & values) {
 
 namespace Utils {
 
-    typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXui;
     typedef Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> ColVectorXd;
-
-    typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXui;
     typedef Eigen::Matrix<double, 1, Eigen::Dynamic, Eigen::RowMajor> RowVectorXd;
     
     typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor> ColMatrixXb;


### PR DESCRIPTION
Improvements:

* Removed noise transcript from EM algorithm. Instead a noise-adjusted read count is calculated. This gets around the noise having an expression value.

Changes to existing options and outputs:

* Removed *ClusterRelativeExpression* from output. Can easily be regenerated by calculating the relative read count in each cluster. 

Bug fixes:

* Fixed minor bug in how haplotype probabilities were calculated.
