### PR TITLE
Added haplotyping output to haplotype-transcripts inference mode

### DIFF
--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -42,12 +42,12 @@ struct PathClusterEstimates {
 
     vector<PathInfo> paths;
 
-    Eigen::RowVectorXd posteriors;
+    vector<double> posteriors;
+    vector<vector<uint32_t> > path_group_sets;
+
     Eigen::RowVectorXd abundances;
 
     vector<CountSamples> gibbs_read_count_samples;
-
-    vector<vector<uint32_t> > path_group_sets;
 
     void generateGroupsRecursive(const uint32_t num_components, const uint32_t group_size, vector<uint32_t> cur_group) {
 
@@ -81,17 +81,24 @@ struct PathClusterEstimates {
 
             generateGroupsRecursive(num_components, group_size, vector<uint>());
             num_components = path_group_sets.size();
+        
+            if (init_zero) {
+
+                posteriors = vector<double>(num_components, 0);
+
+            } else {
+
+                posteriors = vector<double>(num_components, 1 / static_cast<float>(num_components));
+            }
         }
 
         if (init_zero) {
 
-            posteriors = Eigen::RowVectorXd::Zero(1, num_components);
             abundances = Eigen::RowVectorXd::Zero(1, num_components);
 
         } else {
 
-            posteriors = Eigen::RowVectorXd::Constant(num_components, 1);
-            abundances = Eigen::RowVectorXd::Constant(num_components, 1 / static_cast<float>(num_components));
+            abundances = Eigen::RowVectorXd::Constant(1, num_components, 1 / static_cast<float>(num_components));
         }
     }
 };

--- a/src/path_posterior_estimator.cpp
+++ b/src/path_posterior_estimator.cpp
@@ -26,9 +26,9 @@ void PathPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_estima
 
         calculatePathGroupPosteriorsFull(path_cluster_estimates, read_path_probs, noise_probs, read_counts, path_counts, 1);
 
-        assert(path_cluster_estimates->posteriors.cols() == read_path_probs.cols());
-        assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->paths.size());
-        assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->path_group_sets.size());
+        assert(path_cluster_estimates->posteriors.size() == read_path_probs.cols());
+        assert(path_cluster_estimates->posteriors.size() == path_cluster_estimates->paths.size());
+        assert(path_cluster_estimates->posteriors.size() == path_cluster_estimates->path_group_sets.size());
 
     } else {
 
@@ -72,7 +72,7 @@ void PathGroupPosteriorEstimator::estimate(PathClusterEstimates * path_cluster_e
             }
         }
 
-        assert(path_cluster_estimates->posteriors.cols() == path_cluster_estimates->path_group_sets.size());
+        assert(path_cluster_estimates->posteriors.size() == path_cluster_estimates->path_group_sets.size());
 
     } else {
 

--- a/src/threaded_output_writer.hpp
+++ b/src/threaded_output_writer.hpp
@@ -52,12 +52,12 @@ class ProbabilityClusterWriter : public ThreadedOutputWriter {
         const uint32_t prob_precision_digits;
 };
 
-class GibbsSamplesWriter : public ThreadedOutputWriter {
+class ReadCountGibbsSamplesWriter : public ThreadedOutputWriter {
 
     public: 
         
-        GibbsSamplesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t num_gibbs_samples_in);
-        ~GibbsSamplesWriter() {};
+        ReadCountGibbsSamplesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t num_gibbs_samples_in);
+        ~ReadCountGibbsSamplesWriter() {};
 
         void addSamples(const pair<uint32_t, PathClusterEstimates> & path_cluster_estimate);
 
@@ -66,12 +66,12 @@ class GibbsSamplesWriter : public ThreadedOutputWriter {
         const uint32_t num_gibbs_samples; 
 };
 
-class PosteriorEstimatesWriter : public ThreadedOutputWriter {
+class HaplotypeEstimatesWriter : public ThreadedOutputWriter {
 
     public: 
         
-        PosteriorEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t ploidy_in, const double min_posterior_in);
-        ~PosteriorEstimatesWriter() {};
+        HaplotypeEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t ploidy_in, const double min_posterior_in);
+        ~HaplotypeEstimatesWriter() {};
 
         void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
 
@@ -84,14 +84,29 @@ class PosteriorEstimatesWriter : public ThreadedOutputWriter {
 class AbundanceEstimatesWriter : public ThreadedOutputWriter {
 
     public: 
-    	
-    	AbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const double total_transcript_count_in);
-    	~AbundanceEstimatesWriter() {};
+        
+        AbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const double total_transcript_count_in);
+        ~AbundanceEstimatesWriter() {};
 
         void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
 
     private:
 
+        const double total_transcript_count;
+};
+
+class HaplotypeAbundanceEstimatesWriter : public ThreadedOutputWriter {
+
+    public: 
+    	
+    	HaplotypeAbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t ploidy_in, const double total_transcript_count_in);
+    	~HaplotypeAbundanceEstimatesWriter() {};
+
+        void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
+
+    private:
+
+        const uint32_t ploidy;
         const double total_transcript_count;
 };
 


### PR DESCRIPTION
Improvements:

* Added output file containing the inferred posterior probabilities of haplotype combinations (e.g. diplotypes) when using the *haplotype-transcripts* inference mode. The file will have the name \<output-prefix\>_haps.txt.

Changes to existing options and outputs:

* Renamed "PosteriorProbability" to "Probability" in haplotyping output when using the *haplotypes* inference model. This was done to make the naming more consistent with the other outputs. 
* Removed "HaplotypeProbability" from abundance output when using the *transcripts* or *strains* inference model. There is no haplotype inference in these models and thus the value was always 1. 
