### PR TITLE
Added non-quality score and max fragment length options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The method currently contains four different inference models. Each model have b
 * Use `-s` for single-end reads. Note that the fragment length distribution will still be used for calculating the effective path length.
 * Use `-l` for single-molecule long-reads. This is identical to the single-end mode (`-s`), but does not use effective path length normalization.
 
-**Note that rpvg assumes that the default scoring parameters were used for the alignment using either vg map or vg mpmap**.
+Note that rpvg assumes that the default scoring parameters were used for the alignment using either vg map or vg mpmap.
 
 #### Fragment length distribution:
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The method currently contains four different inference models. Each model have b
 * Use `-s` for single-end reads. Note that the fragment length distribution will still be used for calculating the effective path length.
 * Use `-l` for single-molecule long-reads. This is identical to the single-end mode (`-s`), but does not use effective path length normalization.
 
+**Note that rpvg assumes that the default scoring parameters were used for the alignment using either vg map or vg mpmap**.
+
 #### Fragment length distribution:
 
 The fragment length distribution parameters are learned by rpvg. However, in order to learn this the maximum expected fragment length is needed. This is calculated from the expected fragment length distribution mean and standard deviation, which can be given using `-m` and `-d`, respectively. If these are not given the method will look for the parameters in the alignment file and pick the first values that it finds. The input parameters (`-m` and `-d`) are overwritten by the values estimated by rpvg when calculating the read-path probabilities. When the input is single-end reads (`-s`) the expected mean (`-m`) and standard deviation (`-d`) is required as it can not be estimated by rpvg and is needed for the effective path length calculation.

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -624,13 +624,6 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPaths(vector<Align
 template<class AlignmentType>
 vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPaths(const AlignmentType & alignment_1, const AlignmentType & alignment_2) const {
 
-    #pragma omp critical
-    { 
-        cerr << endl;   
-        cerr << Utils::pb2json(alignment_1) << endl;
-        cerr << Utils::pb2json(alignment_2) << endl;
-    }
-
 #ifdef debug
 
     cerr << endl;

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -624,6 +624,13 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPaths(vector<Align
 template<class AlignmentType>
 vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findPairedAlignmentPaths(const AlignmentType & alignment_1, const AlignmentType & alignment_2) const {
 
+    #pragma omp critical
+    { 
+        cerr << endl;   
+        cerr << Utils::pb2json(alignment_1) << endl;
+        cerr << Utils::pb2json(alignment_2) << endl;
+    }
+
 #ifdef debug
 
     cerr << endl;

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -12,7 +12,7 @@ static const int32_t max_noise_score_diff = (Utils::default_match + Utils::defau
 
 
 template<class AlignmentType>
-AlignmentPathFinder<AlignmentType>::AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const bool use_allelic_mapq_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const int32_t max_score_diff_in, const double min_best_score_filter_in) : paths_index(paths_index_in), library_type(library_type_in), use_allelic_mapq(use_allelic_mapq_in), max_pair_frag_length(max_pair_frag_length_in), max_partial_offset(max_partial_offset_in), est_missing_noise_prob(est_missing_noise_prob_in), max_score_diff(max_score_diff_in), min_best_score_filter(min_best_score_filter_in) {}
+AlignmentPathFinder<AlignmentType>::AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const bool score_not_qual_in, const bool use_allelic_mapq_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const int32_t max_score_diff_in, const double min_best_score_filter_in) : paths_index(paths_index_in), library_type(library_type_in), score_not_qual(score_not_qual_in), use_allelic_mapq(use_allelic_mapq_in), max_pair_frag_length(max_pair_frag_length_in), max_partial_offset(max_partial_offset_in), est_missing_noise_prob(est_missing_noise_prob_in), max_score_diff(max_score_diff_in), min_best_score_filter(min_best_score_filter_in) {}
         
 template<class AlignmentType>
 bool AlignmentPathFinder<AlignmentType>::alignmentHasPath(const vg::Alignment & alignment) const {
@@ -51,7 +51,7 @@ int32_t AlignmentPathFinder<AlignmentType>::alignmentScore(const char & quality)
 template<class AlignmentType>
 int32_t AlignmentPathFinder<AlignmentType>::alignmentScore(const string & quality, const uint32_t & start_offset, const uint32_t & length) const {
 
-    if (quality.empty()) {
+    if (score_not_qual || quality.empty()) {
 
         return length;
     }
@@ -70,7 +70,7 @@ int32_t AlignmentPathFinder<AlignmentType>::alignmentScore(const string & qualit
 template<class AlignmentType>
 int32_t AlignmentPathFinder<AlignmentType>::optimalAlignmentScore(const string & quality, const uint32_t seq_length) const {
 
-    if (quality.empty()) {
+    if (score_not_qual || quality.empty()) {
 
         return seq_length * Utils::default_match + 2 * Utils::default_full_length_bonus;
     } 

--- a/src/alignment_path_finder.hpp
+++ b/src/alignment_path_finder.hpp
@@ -17,7 +17,7 @@ class AlignmentPathFinder {
 
     public: 
     
-       	AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const bool use_allelic_mapq_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const int32_t max_score_diff_in, const double min_best_score_filter_in);
+       	AlignmentPathFinder(const PathsIndex & paths_index_in, const string library_type_in, const bool score_not_qual_in, const bool use_allelic_mapq_in, const uint32_t max_pair_frag_length_in, const uint32_t max_partial_offset_in, const bool est_missing_noise_prob_in, const int32_t max_score_diff_in, const double min_best_score_filter_in);
 
 		vector<AlignmentPath> findAlignmentPaths(const AlignmentType & alignment) const;
 		vector<AlignmentPath> findPairedAlignmentPaths(const AlignmentType & alignment_1, const AlignmentType & alignment_2) const;
@@ -27,6 +27,7 @@ class AlignmentPathFinder {
        	const PathsIndex & paths_index;
        	const string library_type;
 
+       	const bool score_not_qual;
        	const bool use_allelic_mapq;
 
        	const uint32_t max_pair_frag_length;

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -10,28 +10,24 @@
 
 //#define debug_skew_normal_fit
 
-static const uint32_t max_length_sd_multiplicity = 10;
-
 
 FragmentLengthDist::FragmentLengthDist() : loc_(0), scale_(1), shape_(0) {
 
     assert(isValid());
-    setMaxLength();
+    setMaxLength(1);
 }
 
-FragmentLengthDist::FragmentLengthDist(const double mean_in, const double sd_in) : FragmentLengthDist(mean_in, sd_in, 0.0) {
-    
-}
+FragmentLengthDist::FragmentLengthDist(const double mean_in, const double sd_in, const uint32_t sd_max_multi) : FragmentLengthDist(mean_in, sd_in, 0.0, sd_max_multi) {}
 
-FragmentLengthDist::FragmentLengthDist(const double loc_in, const double scale_in, const double shape_in) : loc_(loc_in), scale_(scale_in), shape_(shape_in) {
+FragmentLengthDist::FragmentLengthDist(const double loc_in, const double scale_in, const double shape_in, const uint32_t sd_max_multi) : loc_(loc_in), scale_(scale_in), shape_(shape_in) {
 
     assert(isValid());
 
-    setMaxLength();
+    setMaxLength(sd_max_multi);
     setLogProbBuffer(max_length_);
 }
 
-FragmentLengthDist::FragmentLengthDist(istream * alignments_istream, const bool is_multipath) {
+FragmentLengthDist::FragmentLengthDist(istream * alignments_istream, const bool is_multipath, const uint32_t sd_max_multi) {
 
     assert(alignments_istream->good());
 
@@ -58,11 +54,11 @@ FragmentLengthDist::FragmentLengthDist(istream * alignments_istream, const bool 
 
     assert(isValid());
 
-    setMaxLength();
+    setMaxLength(sd_max_multi);
     setLogProbBuffer(max_length_);
 }
 
-FragmentLengthDist::FragmentLengthDist(const vector<uint32_t> & frag_length_counts, bool skew_normal) {
+FragmentLengthDist::FragmentLengthDist(const vector<uint32_t> & frag_length_counts, const bool skew_normal) {
 
     assert(!frag_length_counts.empty());
     assert(frag_length_counts.front() == 0);
@@ -256,7 +252,7 @@ FragmentLengthDist::FragmentLengthDist(const vector<uint32_t> & frag_length_coun
 
         assert(isValid());
 
-        setMaxLength();
+        max_length_ = frag_length_counts.size();
         setLogProbBuffer(frag_length_counts.size());
     }
 }
@@ -349,14 +345,14 @@ double FragmentLengthDist::logProb(const uint32_t value) const {
     }
 }
 
-void FragmentLengthDist::setMaxLength() {
+void FragmentLengthDist::setMaxLength(const uint32_t sd_max_multi) {
 
     assert(isValid());
 
     double delta = shape_ / sqrt(1.0 + shape_ * shape_);
     double sd = scale_ * (1.0 - 2.0 * delta * delta / Utils::pi);
     
-    max_length_ = ceil(loc_ + sd * max_length_sd_multiplicity);
+    max_length_ = ceil(loc_ + sd * sd_max_multi);
     assert(max_length_ > 0);
 }
 

--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -276,6 +276,27 @@ bool FragmentLengthDist::parseAlignment(const vg::Alignment & alignment) {
         shape_ = 0.0;
         
         return true;     
+    
+    } else if (alignment.has_annotation() && alignment.annotation().fields().count("fragment_length_distribution")) {
+
+        stringstream frag_length_ss = stringstream(alignment.annotation().fields().at("fragment_length_distribution").string_value());
+        string element;
+
+        getline(frag_length_ss, element, ' ');
+        assert(element == "-I");
+
+        getline(frag_length_ss, element, ' ');
+        loc_ = stod(element);
+
+        getline(frag_length_ss, element, ' ');
+        assert(element == "-D");
+
+        getline(frag_length_ss, element);
+        scale_ = stod(element);
+
+        shape_ = 0.0;
+        
+        return true;     
     }
 
     return false;

--- a/src/fragment_length_dist.hpp
+++ b/src/fragment_length_dist.hpp
@@ -15,10 +15,10 @@ class FragmentLengthDist {
     public: 
     	
         FragmentLengthDist();
-        FragmentLengthDist(const double mean_in, const double sd_in);
-        FragmentLengthDist(const double loc_in, const double scale_in, const double shape_in);
-        FragmentLengthDist(istream * alignments_istream, const bool is_multipath);
-        FragmentLengthDist(const vector<uint32_t> & frag_length_counts, bool skew_normal);
+        FragmentLengthDist(const double mean_in, const double sd_in, const uint32_t sd_max_multi);
+        FragmentLengthDist(const double loc_in, const double scale_in, const double shape_in, const uint32_t sd_max_multi);
+        FragmentLengthDist(istream * alignments_istream, const bool is_multipath, const uint32_t sd_max_multi);
+        FragmentLengthDist(const vector<uint32_t> & frag_length_counts, const bool skew_normal);
 
         double loc() const;
         double scale() const;
@@ -40,7 +40,7 @@ class FragmentLengthDist {
 
         vector<double> log_prob_buffer;
 
-        void setMaxLength();
+        void setMaxLength(const uint32_t sd_max_multi);
         void setLogProbBuffer(const uint32_t size); 
 };
 

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 3);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
 
     auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
     REQUIRE(alignment_paths.size() == 3);
@@ -200,7 +200,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end alignment") {
         REQUIRE(paths_index_bd.bidirectional());
         REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", true, false, 1000, 0, true, 20, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths_bd.size() == 2);
@@ -342,7 +342,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 4);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
     
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
     REQUIRE(alignment_paths.size() == 4);
@@ -645,7 +645,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end alignment") {
         REQUIRE(paths_index_bd.bidirectional());
         REQUIRE(paths_index_bd.numberOfPaths() == 3);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", true, false, 1000, 0, true, 20, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_bd.size() == 3);
@@ -757,7 +757,7 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 3);
 
-    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+    AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
 
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
     REQUIRE(alignment_paths.size() == 4);
@@ -1000,7 +1000,7 @@ TEST_CASE("Circular alignment path(s) can be found from a paired-end alignment")
         REQUIRE(paths_index_bd.bidirectional());
         REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder_bd(paths_index_bd, "unstranded", true, false, 1000, 0, true, 20, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_bd.size() == 3);
@@ -1170,7 +1170,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 2);
 
-    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
     
     auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
     REQUIRE(alignment_paths.size() == 3);
@@ -1254,7 +1254,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
         REQUIRE(paths_index_bd.bidirectional());
         REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", true, false, 1000, 0, true, 20, 0);
 
         auto alignment_paths_bd = alignment_path_finder_bd.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths_bd.size() == 3);
@@ -1276,7 +1276,7 @@ TEST_CASE("Alignment path(s) can be found from a single-end multipath alignment"
 
     SECTION("Alignment pairs from a single-end multipath alignment does not estimate missing path noise probability") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", false, 1000, 0, false, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", true, false, 1000, 0, false, 20, 0);
 
         auto alignment_paths_nm = alignment_path_finder_nm.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths_nm.size() == 3);
@@ -1582,7 +1582,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 3);
 
-    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
 
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
     REQUIRE(alignment_paths.size() == 4);
@@ -1897,7 +1897,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(paths_index_bd.bidirectional());
         REQUIRE(paths_index_bd.numberOfPaths() == 2);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bd(paths_index_bd, "unstranded", true, false, 1000, 0, true, 20, 0);
     
         auto alignment_paths_bd = alignment_path_finder_bd.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_bd.size() == 3);
@@ -1914,7 +1914,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Strand-specific paired-end multipath read alignment finds unidirectional alignment path(s)") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "fr", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "fr", true, false, 1000, 0, true, 20, 0);
 
         auto alignment_paths_fr = alignment_path_finder_fr.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_fr.size() == 3);
@@ -1923,7 +1923,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_fr.at(1) == alignment_paths.at(1));
         REQUIRE(alignment_paths_fr.back() == alignment_paths.back());
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_rf(paths_index, "rf", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_rf(paths_index, "rf", true, false, 1000, 0, true, 20, 0);
 
         auto alignment_paths_rf = alignment_path_finder_rf.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_rf.size() == 2);
@@ -1943,7 +1943,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Alignment pairs from a paired-end multipath alignment can use allelic mapping quality") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "unstranded", true, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_fr(paths_index, "unstranded", true, true, 1000, 0, true, 20, 0);
 
         auto alignment_paths_amq = alignment_path_finder_fr.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_amq.size() == 4);
@@ -1975,14 +1975,14 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on length") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len16(paths_index, "unstranded", false, 16, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len16(paths_index, "unstranded", true, false, 16, 0, true, 20, 0);
 
         auto alignment_paths_len16 = alignment_path_finder_len16.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_len16.size() == 4);
         
         REQUIRE(alignment_paths_len16 == alignment_paths);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len12(paths_index, "unstranded", false, 12, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len12(paths_index, "unstranded", true, false, 12, 0, true, 20, 0);
 
         auto alignment_paths_len12 = alignment_path_finder_len12.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_len12.size() == 2);
@@ -1999,7 +1999,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_len12.back().min_mapq == alignment_paths.back().min_mapq);
         REQUIRE(alignment_paths_len12.back().score_sum == alignment_paths.back().score_sum);
         
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len11(paths_index, "unstranded", false, 11, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_len11(paths_index, "unstranded", true, false, 11, 0, true, 20, 0);
 
         auto alignment_paths_len11 = alignment_path_finder_len11.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_len11.empty());
@@ -2007,14 +2007,14 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on maximum score difference") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd7(paths_index, "unstranded", false, 1000, 0, true, 7, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd7(paths_index, "unstranded", true, false, 1000, 0, true, 7, 0);
 
         auto alignment_paths_sd7 = alignment_path_finder_sd7.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_sd7.size() == 4);
 
         assert(alignment_paths_sd7 == alignment_paths);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd6(paths_index, "unstranded", false, 1000, 0, true, 6, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd6(paths_index, "unstranded", true, false, 1000, 0, true, 6, 0);
 
         auto alignment_paths_sd6 = alignment_path_finder_sd6.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_sd6.size() == 3);
@@ -2037,7 +2037,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_sd6.back().min_mapq == alignment_paths.back().min_mapq);
         REQUIRE(alignment_paths_sd6.back().score_sum == -48604);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd2(paths_index, "unstranded", false, 1000, 0, true, 2, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd2(paths_index, "unstranded", true, false, 1000, 0, true, 2, 0);
 
         auto alignment_paths_sd2 = alignment_path_finder_sd2.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_sd2.size() == 3);
@@ -2060,7 +2060,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
         REQUIRE(alignment_paths_sd2.back().min_mapq == alignment_paths.back().min_mapq);
         REQUIRE(alignment_paths_sd2.back().score_sum == -48449);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd1(paths_index, "unstranded", false, 1000, 0, true, 1, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_sd1(paths_index, "unstranded", true, false, 1000, 0, true, 1, 0);
 
         auto alignment_paths_sd1 = alignment_path_finder_sd1.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_sd1.empty());
@@ -2068,14 +2068,14 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Alignment pairs from a paired-end multipath alignment are filtered based on best score fraction") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs25(paths_index, "unstranded", false, 1000, 0, true, 20, 0.25);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs25(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0.25);
 
         auto alignment_paths_bs25 = alignment_path_finder_bs25.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_bs25.size() == 4);
 
         assert(alignment_paths_bs25 == alignment_paths);
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs30(paths_index, "unstranded", false, 1000, 0, true, 20, 0.30);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_bs30(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0.30);
 
         auto alignment_paths_bs30 = alignment_path_finder_bs30.findPairedAlignmentPaths(alignment_1, alignment_2);    
         REQUIRE(alignment_paths_bs30.size() == 4);
@@ -2093,7 +2093,7 @@ TEST_CASE("Alignment path(s) can be found from a paired-end multipath alignment"
 
     SECTION("Alignment pairs from a paired-end multipath alignment does not estimate missing path noise probability") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", false, 1000, 0, false, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_nm(paths_index, "unstranded", true, false, 1000, 0, false, 20, 0);
 
         auto alignment_paths_nm = alignment_path_finder_nm.findPairedAlignmentPaths(alignment_1, alignment_2);
         REQUIRE(alignment_paths_nm.size() == 4);
@@ -2309,7 +2309,7 @@ TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath al
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 3);
 
-    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", false, 1000, 4, true, 20, 0);
+    AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 4, true, 20, 0);
 
     auto alignment_paths = alignment_path_finder.findPairedAlignmentPaths(alignment_1, alignment_2);
     REQUIRE(alignment_paths.size() == 10);
@@ -2389,7 +2389,7 @@ TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath al
 
     SECTION("Partial alignment pairs from a paired-end multipath alignment are filtered based on maximum internal offset") {
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int3(paths_index, "unstranded", false, 1000, 3, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int3(paths_index, "unstranded", true, false, 1000, 3, true, 20, 0);
 
         auto alignment_paths_int3 = alignment_path_finder_int3.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_int3.size() == 7);
@@ -2402,7 +2402,7 @@ TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath al
         REQUIRE(alignment_paths_int3.at(5) == alignment_paths.at(5));
         REQUIRE(alignment_paths_int3.back() == alignment_paths.back());
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int2(paths_index, "unstranded", false, 1000, 2, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int2(paths_index, "unstranded", true, false, 1000, 2, true, 20, 0);
 
         auto alignment_paths_int2 = alignment_path_finder_int2.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_int2.size() == 4);
@@ -2412,7 +2412,7 @@ TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath al
         REQUIRE(alignment_paths_int2.at(2) == alignment_paths.at(5));
         REQUIRE(alignment_paths_int2.back() == alignment_paths.back());
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int1(paths_index, "unstranded", false, 1000, 1, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int1(paths_index, "unstranded", true, false, 1000, 1, true, 20, 0);
 
         auto alignment_paths_int1 = alignment_path_finder_int1.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_int1.size() == 2);
@@ -2420,7 +2420,7 @@ TEST_CASE("Partial alignment path(s) can be found from a paired-end multipath al
         REQUIRE(alignment_paths_int1.front() == alignment_paths.at(5));
         REQUIRE(alignment_paths_int1.back() == alignment_paths.back());
 
-        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int0(paths_index, "unstranded", false, 1000, 0, true, 20, 0);
+        AlignmentPathFinder<vg::MultipathAlignment> alignment_path_finder_int0(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
 
         auto alignment_paths_int0 = alignment_path_finder_int0.findPairedAlignmentPaths(alignment_1, alignment_2);        
         REQUIRE(alignment_paths_int0.empty());        

--- a/src/tests/fragment_length_dist_test.cpp
+++ b/src/tests/fragment_length_dist_test.cpp
@@ -7,7 +7,7 @@
 
 TEST_CASE("FragmentLengthDist is valid normal distribution") {
     
-	FragmentLengthDist fragment_length_dist(10, 2);
+	FragmentLengthDist fragment_length_dist(10, 2, 10);
 
     REQUIRE(fragment_length_dist.isValid());	
     REQUIRE(fragment_length_dist.maxLength() == 30);
@@ -17,6 +17,13 @@ TEST_CASE("FragmentLengthDist is valid normal distribution") {
     REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(9), fragment_length_dist.logProb(11)));
     REQUIRE(Utils::doubleCompare(fragment_length_dist.logProb(10000), -12475014.11208571307361));
 
+    SECTION("Maximum fragment length can be changed") {
+
+        fragment_length_dist = FragmentLengthDist(10, 2, 5);
+
+        REQUIRE(fragment_length_dist.isValid());    
+        REQUIRE(fragment_length_dist.maxLength() == 20);
+    }
 }
 
 TEST_CASE("FragmentLengthDist is valid skew normal distribution") {
@@ -53,21 +60,21 @@ TEST_CASE("FragmentLengthDist is valid skew normal distribution") {
         for (int mu = 0; mu <= 3; ++mu) {
             for (int sigma = 1; sigma <= 3; ++sigma) {
                 for (int alpha = -3; alpha <= -3; ++alpha) {
-                    FragmentLengthDist distr(mu, sigma, alpha);
+                    FragmentLengthDist distr(mu, sigma, alpha, 10);
                     for (int x = 0; x <= 3; ++x) {
                         if (alpha == 0) {
-                            FragmentLengthDist norm(mu, sigma);
+                            FragmentLengthDist norm(mu, sigma, 10);
                             REQUIRE(Utils::doubleCompare(distr.logProb(x), norm.logProb(x)));
                         }
                         {
-                            FragmentLengthDist other(x, sigma, -alpha);
+                            FragmentLengthDist other(x, sigma, -alpha, 10);
                             REQUIRE(Utils::doubleCompare(distr.logProb(x), other.logProb(mu)));
                         }
                         {
                             // reflect the test point around mu and reverse the skew
                             int reflected = 2 * mu - x;
                             if (reflected >= 0) {
-                                FragmentLengthDist other(mu, sigma, -alpha);
+                                FragmentLengthDist other(mu, sigma, -alpha, 10);
                                 REQUIRE(Utils::doubleCompare(distr.logProb(x), other.logProb(reflected)));
                             }
                         }

--- a/src/tests/paths_index_test.cpp
+++ b/src/tests/paths_index_test.cpp
@@ -66,12 +66,12 @@ TEST_CASE("Path index can calculate path lengths") {
 
 	SECTION("Effective paths length are calculated using fragment length distribution") {
 
-		FragmentLengthDist fragment_length_dist(5, 2);
+		FragmentLengthDist fragment_length_dist(5, 2, 10);
 
     	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 32.889504274642021));
     	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 2.4592743581826583));
 
-    	fragment_length_dist = FragmentLengthDist(20, 1);
+    	fragment_length_dist = FragmentLengthDist(20, 1, 10);
 
     	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(0, fragment_length_dist), 18));
     	REQUIRE(Utils::doubleCompare(paths_index.effectivePathLength(1, fragment_length_dist), 1));

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -9,7 +9,7 @@
 TEST_CASE("Read path probabilities can be calculated from alignment paths") {
     
 	spp::sparse_hash_map<uint32_t, uint32_t> clustered_path_index({{100, 0}, {200, 1}});
-	FragmentLengthDist fragment_length_dist(10, 2);
+	FragmentLengthDist fragment_length_dist(10, 2, 10);
 
 	vector<AlignmentPath> alignment_paths;
 	alignment_paths.emplace_back(make_pair(gbwt::SearchState(), 0), true, 10, 3, 5, 10);


### PR DESCRIPTION
Improvements:

* Added option to specify that the alignment score is not quality adjusted (`--score-not-qual`).
* Added option to specify the maximum fragment length as the number of standard deviations from the mean (`--max-num-sd-frag`).

