### PR TITLE
Added noise to inference and output

### DIFF
--- a/src/fragment_length_dist.cpp
+++ b/src/fragment_length_dist.cpp
@@ -11,10 +11,9 @@
 //#define debug_skew_normal_fit
 
 
-FragmentLengthDist::FragmentLengthDist() : loc_(0), scale_(1), shape_(0) {
+FragmentLengthDist::FragmentLengthDist() : loc_(0), scale_(0), shape_(0), max_length_(0) {
 
-    assert(isValid());
-    setMaxLength(1);
+    assert(!isValid());
 }
 
 FragmentLengthDist::FragmentLengthDist(const double mean_in, const double sd_in, const uint32_t sd_max_multi) : FragmentLengthDist(mean_in, sd_in, 0.0, sd_max_multi) {}

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -623,7 +623,11 @@ void NestedPathAbundanceEstimator::inferPathSubsetAbundance(PathClusterEstimates
 
     for (auto & path_subset: path_subset_samples) {
 
-        assert(path_subset.second >= min_hap_prob);
+        if (path_subset.second < min_hap_prob) {
+
+            continue;
+        }
+        
         sum_hap_prob += path_subset.second;
 
         assert(!path_subset.first.empty());

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -101,7 +101,8 @@ void PathAbundanceEstimator::EMAbundanceEstimator(PathClusterEstimates * path_cl
 
         if (abundances(0, i) < min_em_abundance) {
 
-            path_cluster_estimates->noise_count += abundances(0, i) * path_cluster_estimates->total_count;            
+            path_cluster_estimates->noise_count += abundances(0, i) * path_cluster_estimates->total_count;
+            path_cluster_estimates->abundances.at(i) = 0;            
 
         } else {
 

--- a/src/path_abundance_estimator.hpp
+++ b/src/path_abundance_estimator.hpp
@@ -32,8 +32,8 @@ class PathAbundanceEstimator : public PathEstimator {
         const uint32_t num_gibbs_samples;
         const uint32_t gibbs_thin_its;
 
-        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts, const double total_read_count) const;
-        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts, const double total_read_count, const double gamma, mt19937 * mt_rng, const uint32_t num_samples) const;
+        void EMAbundanceEstimator(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts) const;
+        void gibbsReadCountSampler(PathClusterEstimates * path_cluster_estimates, const Utils::ColMatrixXd & read_path_probs, const Utils::RowVectorXd & read_counts, const double gamma, mt19937 * mt_rng, const uint32_t num_samples) const;
 };
 
 class MinimumPathAbundanceEstimator : public PathAbundanceEstimator {

--- a/src/path_cluster_estimates.hpp
+++ b/src/path_cluster_estimates.hpp
@@ -35,7 +35,9 @@ struct PathInfo {
 struct CountSamples {
 
     vector<uint32_t> path_ids;
-    vector<double> samples;
+
+    vector<double> noise_samples;
+    vector<double> abundance_samples;
 
     CountSamples() {}
 };
@@ -49,7 +51,16 @@ struct PathClusterEstimates {
     vector<double> posteriors;
     vector<double> abundances;
 
+    double noise_count;
+    double total_count;
+
     vector<CountSamples> gibbs_read_count_samples;
+
+    PathClusterEstimates() {
+
+        noise_count = 0;
+        total_count = 0;
+    }
 
     void generateGroupsRecursive(const uint32_t num_components, const uint32_t group_size, vector<uint32_t> cur_group) {
 
@@ -83,6 +94,9 @@ struct PathClusterEstimates {
 
         posteriors.clear();
         abundances.clear();
+
+        noise_count = 0;
+        total_count = 0; 
         
         gibbs_read_count_samples.clear();
 

--- a/src/path_estimator.hpp
+++ b/src/path_estimator.hpp
@@ -27,7 +27,7 @@ class PathEstimator {
         const double prob_precision;
 
         void constructProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const uint32_t num_paths) const; 
-        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths, const bool remove_zero_row) const;
+        void constructPartialProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<uint32_t> & path_ids, const uint32_t num_paths) const;
         void constructGroupedProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, Utils::ColVectorXd * noise_probs, Utils::RowVectorXd * read_counts, const vector<ReadPathProbabilities> & cluster_probs, const vector<vector<uint32_t> > & path_groups, const uint32_t num_paths) const;
 
         void addNoiseAndNormalizeProbabilityMatrix(Utils::ColMatrixXd * read_path_probs, const Utils::ColVectorXd & noise_probs) const;

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -285,8 +285,6 @@ AbundanceEstimatesWriter::AbundanceEstimatesWriter(const string filename_prefix,
     noise_count = 0;
 
     auto out_sstream = new stringstream;
-    *out_sstream << setprecision(out_precision_digits);
-
     *out_sstream << "Name\tClusterID\tLength\tEffectiveLength\tReadCount\tTPM" << endl;
     output_queue->push(out_sstream);
 }

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -131,7 +131,7 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
 
             for (auto & noise_sample: count_samples.noise_samples) {
 
-                assert(noise_sample <= path_cluster_estimate.second.total_count);
+                assert(noise_sample < path_cluster_estimate.second.total_count || Utils::doubleCompare(noise_sample, path_cluster_estimate.second.total_count));
 
                 noise_counts.at(noise_count_idx) += noise_sample;
                 ++noise_count_idx;  

--- a/src/threaded_output_writer.cpp
+++ b/src/threaded_output_writer.cpp
@@ -3,6 +3,8 @@
 
 #include <iomanip>
 
+const uint32_t out_precision_digits = 8;
+
 ThreadedOutputWriter::ThreadedOutputWriter(const string & filename, const string & compression_mode, const uint32_t num_threads) {
 
     writer_stream = bgzf_open(filename.c_str(), compression_mode.c_str());
@@ -35,7 +37,7 @@ void ThreadedOutputWriter::write() {
 }
 
 
-ProbabilityClusterWriter::ProbabilityClusterWriter(const string filename_prefix, const uint32_t num_threads, const double prob_precision_in) : ThreadedOutputWriter(filename_prefix + ".txt.gz", "wg", num_threads), prob_precision(prob_precision_in), prob_precision_digits(ceil(-1 * log10(prob_precision))) {}
+ProbabilityClusterWriter::ProbabilityClusterWriter(const string filename_prefix, const uint32_t num_threads, const double prob_precision_in) : ThreadedOutputWriter(filename_prefix + ".txt.gz", "wg", num_threads), prob_precision(prob_precision_in), prob_precision_digits(max(out_precision_digits, static_cast<uint32_t>(ceil(-1 * log10(prob_precision))))) {}
 
 void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & read_path_cluster_probs, const vector<PathInfo> & cluster_paths) {
 
@@ -46,7 +48,7 @@ void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & 
         auto out_sstream = new stringstream;
 
         *out_sstream << "#" << endl;
-        *out_sstream << setprecision(3);
+        *out_sstream << setprecision(out_precision_digits);
         *out_sstream << cluster_paths.front().name << "," << cluster_paths.front().length << "," << cluster_paths.front().effective_length;
 
         for (size_t i = 1; i < cluster_paths.size(); ++i) {
@@ -95,6 +97,8 @@ void ProbabilityClusterWriter::addCluster(const vector<ReadPathProbabilities> & 
 
 ReadCountGibbsSamplesWriter::ReadCountGibbsSamplesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t num_gibbs_samples_in) : ThreadedOutputWriter(filename_prefix + ".txt.gz", "wg", num_threads), num_gibbs_samples(num_gibbs_samples_in) {
 
+    noise_counts = vector<double>(num_gibbs_samples, 0);
+
     auto out_sstream = new stringstream;
     *out_sstream << "Name\tClusterID";
 
@@ -111,6 +115,8 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
 
     if (!path_cluster_estimate.second.gibbs_read_count_samples.empty()) {
 
+        uint32_t noise_count_idx = 0;
+
         vector<vector<uint32_t> > path_gibbs_sampling_index(path_cluster_estimate.second.paths.size());
 
         for (size_t i = 0; i < path_cluster_estimate.second.gibbs_read_count_samples.size(); ++i) {
@@ -118,9 +124,18 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
             const CountSamples & count_samples = path_cluster_estimate.second.gibbs_read_count_samples.at(i);
 
             assert(!count_samples.path_ids.empty());
-            
-            assert(!count_samples.samples.empty());
-            assert(count_samples.samples.size() % count_samples.path_ids.size() == 0);
+            assert(!count_samples.abundance_samples.empty());
+
+            assert(count_samples.abundance_samples.size() % count_samples.path_ids.size() == 0);
+            assert(count_samples.abundance_samples.size() / count_samples.path_ids.size() == count_samples.noise_samples.size());
+
+            for (auto & noise_sample: count_samples.noise_samples) {
+
+                assert(noise_sample <= path_cluster_estimate.second.total_count);
+
+                noise_counts.at(noise_count_idx) += noise_sample;
+                ++noise_count_idx;  
+            }
 
             for (size_t j = 0; j < count_samples.path_ids.size(); ++j) {
 
@@ -135,7 +150,14 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
             }            
         }
 
+        while (noise_count_idx < num_gibbs_samples) {
+
+            noise_counts.at(noise_count_idx) += path_cluster_estimate.second.total_count;
+            ++noise_count_idx;                    
+        }
+
         auto out_sstream = new stringstream;
+        *out_sstream << setprecision(out_precision_digits);
 
         for (size_t i = 0; i < path_gibbs_sampling_index.size(); ++i) {
 
@@ -154,7 +176,7 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
 
                     if (sampling_indices.at(j) == numeric_limits<uint32_t>::max()) {
 
-                        for (size_t k = 0; k < count_samples.samples.size() / count_samples.path_ids.size(); ++k) {
+                        for (size_t k = 0; k < count_samples.abundance_samples.size() / count_samples.path_ids.size(); ++k) {
 
                             *out_sstream << "\t0";
                             ++num_samples;
@@ -162,9 +184,9 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
 
                     } else {
 
-                        for (size_t k = 0; k < count_samples.samples.size() / count_samples.path_ids.size(); ++k) {
+                        for (size_t k = 0; k < count_samples.abundance_samples.size() / count_samples.path_ids.size(); ++k) {
 
-                            *out_sstream << "\t" << count_samples.samples.at(k * count_samples.path_ids.size() + sampling_indices.at(j));
+                            *out_sstream << "\t" << count_samples.abundance_samples.at(k * count_samples.path_ids.size() + sampling_indices.at(j));
                             ++num_samples;
                         }
                     }
@@ -176,13 +198,35 @@ void ReadCountGibbsSamplesWriter::addSamples(const pair<uint32_t, PathClusterEst
                     ++num_samples;                    
                 }
 
-                assert(num_samples == num_gibbs_samples);
                 *out_sstream << endl;                
             }
         }
 
         output_queue->push(out_sstream);
+    
+    } else {
+
+        for (auto & noise_count: noise_counts) {
+
+            noise_count += path_cluster_estimate.second.total_count;
+        }
     }
+}
+
+void ReadCountGibbsSamplesWriter::addNoiseTranscript(const uint32_t unaligned_read_count) {
+    
+    auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
+
+    *out_sstream << "Unknown\t0";
+
+    for (auto & noise_count: noise_counts) {
+
+        *out_sstream << "\t" << noise_count + unaligned_read_count;
+    }
+
+    *out_sstream << endl;
+    output_queue->push(out_sstream);
 }
 
 
@@ -202,6 +246,7 @@ JointHaplotypeEstimatesWriter::JointHaplotypeEstimatesWriter(const string filena
 void JointHaplotypeEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates) {
 
     auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
 
     for (auto & cur_estimates: path_cluster_estimates) {
 
@@ -237,7 +282,11 @@ void JointHaplotypeEstimatesWriter::addEstimates(const vector<pair<uint32_t, Pat
 
 AbundanceEstimatesWriter::AbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const double total_transcript_count_in) : ThreadedOutputWriter(filename_prefix + ".txt", "wu", num_threads), total_transcript_count(total_transcript_count_in) {
 
+    noise_count = 0;
+
     auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
+
     *out_sstream << "Name\tClusterID\tLength\tEffectiveLength\tReadCount\tTPM" << endl;
     output_queue->push(out_sstream);
 }
@@ -245,11 +294,14 @@ AbundanceEstimatesWriter::AbundanceEstimatesWriter(const string filename_prefix,
 void AbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates) {
 
     auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
 
     for (auto & cur_estimates: path_cluster_estimates) {
 
         assert(cur_estimates.second.paths.size() == cur_estimates.second.path_group_sets.size());
         assert(cur_estimates.second.paths.size() == cur_estimates.second.abundances.size());
+
+        double abundance_sum = 0;
 
         for (size_t i = 0; i < cur_estimates.second.path_group_sets.size(); ++i) {
 
@@ -270,14 +322,32 @@ void AbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClus
             *out_sstream << "\t" << cur_estimates.second.abundances.at(i);
             *out_sstream << "\t" << transcript_count / total_transcript_count * pow(10, 6);
             *out_sstream << endl;
+
+            abundance_sum += cur_estimates.second.abundances.at(i);
         }
+
+        assert(cur_estimates.second.noise_count < cur_estimates.second.total_count || Utils::doubleCompare(cur_estimates.second.noise_count, cur_estimates.second.total_count));
+        assert(Utils::doubleCompare(abundance_sum + cur_estimates.second.noise_count, cur_estimates.second.total_count));
+
+        noise_count += cur_estimates.second.noise_count;
     }
     
     output_queue->push(out_sstream);
 }
 
+void AbundanceEstimatesWriter::addNoiseTranscript(const uint32_t unaligned_read_count) {
+    
+    auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
+
+    *out_sstream << "Unknown\t0\t0\t0\t" << noise_count + unaligned_read_count << "\t0" << endl;
+    output_queue->push(out_sstream);
+}
+
 
 HaplotypeAbundanceEstimatesWriter::HaplotypeAbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t ploidy_in, const double total_transcript_count_in) : ThreadedOutputWriter(filename_prefix + ".txt", "wu", num_threads), ploidy(ploidy_in), total_transcript_count(total_transcript_count_in) {
+
+    noise_count = 0;
 
     auto out_sstream = new stringstream;
     *out_sstream << "Name\tClusterID\tLength\tEffectiveLength\tHaplotypeProbability\tReadCount\tTPM" << endl;
@@ -287,6 +357,7 @@ HaplotypeAbundanceEstimatesWriter::HaplotypeAbundanceEstimatesWriter(const strin
 void HaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates) {
 
     auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
 
     for (auto & cur_estimates: path_cluster_estimates) {
 
@@ -321,6 +392,8 @@ void HaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t,
 
         assert(abundances_it == cur_estimates.second.abundances.end());
 
+        double abundance_sum = 0;
+
         for (size_t i = 0; i < cur_estimates.second.paths.size(); ++i) {
 
             double transcript_count = 0;
@@ -338,14 +411,31 @@ void HaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t,
             *out_sstream << "\t" << read_counts.at(i);
             *out_sstream << "\t" << transcript_count / total_transcript_count * pow(10, 6);
             *out_sstream << endl;
+
+            abundance_sum += read_counts.at(i);
         }
+
+        assert(cur_estimates.second.noise_count < cur_estimates.second.total_count || Utils::doubleCompare(cur_estimates.second.noise_count, cur_estimates.second.total_count));
+        assert(Utils::doubleCompare(abundance_sum + cur_estimates.second.noise_count, cur_estimates.second.total_count));
+
+        noise_count += cur_estimates.second.noise_count;
     }
     
     output_queue->push(out_sstream);
 }
 
+void HaplotypeAbundanceEstimatesWriter::addNoiseTranscript(const uint32_t unaligned_read_count) {
+    
+    auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
+
+    *out_sstream << "Unknown\t0\t0\t0\t0\t" << noise_count + unaligned_read_count << "\t0" << endl;
+    output_queue->push(out_sstream);
+}
 
 JointHaplotypeAbundanceEstimatesWriter::JointHaplotypeAbundanceEstimatesWriter(const string filename_prefix, const uint32_t num_threads, const uint32_t ploidy_in, const double min_posterior_in, const double total_transcript_count_in) : ThreadedOutputWriter(filename_prefix + ".txt", "wu", num_threads), ploidy(ploidy_in), min_posterior(min_posterior_in), total_transcript_count(total_transcript_count_in) {
+
+    noise_counts = vector<double>(ploidy, 0);
 
     auto out_sstream = new stringstream;
 
@@ -368,12 +458,14 @@ JointHaplotypeAbundanceEstimatesWriter::JointHaplotypeAbundanceEstimatesWriter(c
 void JointHaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates) {
 
     auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
 
     for (auto & cur_estimates: path_cluster_estimates) {
 
         assert(cur_estimates.second.posteriors.size() == cur_estimates.second.path_group_sets.size());
 
         auto abundances_it = cur_estimates.second.abundances.begin();
+        double abundance_sum = 0;
 
         for (size_t i = 0; i < cur_estimates.second.path_group_sets.size(); ++i) {
 
@@ -398,6 +490,7 @@ void JointHaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint
                 for (auto & path: cur_estimates.second.path_group_sets.at(i)) {
 
                     *out_sstream << "\t" << *abundances_it;
+                    abundance_sum += *abundances_it;
 
                     double transcript_count = 0;
 
@@ -420,7 +513,37 @@ void JointHaplotypeAbundanceEstimatesWriter::addEstimates(const vector<pair<uint
         }
 
         assert(abundances_it == cur_estimates.second.abundances.end());
+
+        assert(cur_estimates.second.noise_count < cur_estimates.second.total_count || Utils::doubleCompare(cur_estimates.second.noise_count, cur_estimates.second.total_count));
+        assert(Utils::doubleCompare(abundance_sum + cur_estimates.second.noise_count, cur_estimates.second.total_count));
+
+        for (auto & noise_count: noise_counts) {
+
+            noise_count += cur_estimates.second.noise_count / noise_counts.size();
+        }
     }
 
     output_queue->push(out_sstream);
 }
+
+void JointHaplotypeAbundanceEstimatesWriter::addNoiseTranscript(const uint32_t unaligned_read_count) {
+    
+    auto out_sstream = new stringstream;
+    *out_sstream << setprecision(out_precision_digits);
+
+    for (uint32_t i = 0; i < ploidy; ++i) {
+
+        *out_sstream << "Unknown\t";
+    }
+
+    *out_sstream << "0\t0";
+
+    for (auto & noise_count: noise_counts) {
+
+        *out_sstream << "\t" << noise_count + static_cast<float>(unaligned_read_count) / noise_counts.size() << "\t0";
+    }
+
+    *out_sstream << endl;
+    output_queue->push(out_sstream);
+}
+

--- a/src/threaded_output_writer.hpp
+++ b/src/threaded_output_writer.hpp
@@ -60,10 +60,13 @@ class ReadCountGibbsSamplesWriter : public ThreadedOutputWriter {
         ~ReadCountGibbsSamplesWriter() {};
 
         void addSamples(const pair<uint32_t, PathClusterEstimates> & path_cluster_estimate);
+        void addNoiseTranscript(const uint32_t unaligned_read_count);
 
     private:
 
         const uint32_t num_gibbs_samples;
+
+        vector<double> noise_counts;
 };
 
 class JointHaplotypeEstimatesWriter : public ThreadedOutputWriter {
@@ -89,10 +92,13 @@ class AbundanceEstimatesWriter : public ThreadedOutputWriter {
         ~AbundanceEstimatesWriter() {};
 
         void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
+        void addNoiseTranscript(const uint32_t unaligned_read_count);
 
     private:
 
         const double total_transcript_count;
+
+        double noise_count;
 };
 
 class HaplotypeAbundanceEstimatesWriter : public ThreadedOutputWriter {
@@ -103,11 +109,14 @@ class HaplotypeAbundanceEstimatesWriter : public ThreadedOutputWriter {
     	~HaplotypeAbundanceEstimatesWriter() {};
 
         void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
+        void addNoiseTranscript(const uint32_t unaligned_read_count);
 
     private:
 
         const uint32_t ploidy;
         const double total_transcript_count;
+
+        double noise_count;        
 };
 
 class JointHaplotypeAbundanceEstimatesWriter : public ThreadedOutputWriter {
@@ -118,12 +127,15 @@ class JointHaplotypeAbundanceEstimatesWriter : public ThreadedOutputWriter {
         ~JointHaplotypeAbundanceEstimatesWriter() {};
 
         void addEstimates(const vector<pair<uint32_t, PathClusterEstimates> > & path_cluster_estimates);
+        void addNoiseTranscript(const uint32_t unaligned_read_count);
 
     private:
 
         const uint32_t ploidy;
         const double min_posterior;
         const double total_transcript_count;
+
+        vector<double> noise_counts;
 };
 
 #endif


### PR DESCRIPTION
Improvements:

* Added a "noise" transcript to model the assignment of uncertain reads (low mapping quality) in the expression inference. 

Changes to existing options and outputs:

* Added the estimated noise read count to the output as an "Unknown" transcript. This count includes unmapped reads, reads not aligning to any paths and uncertain reads (e.g. low mapping quality). 
