### PR TITLE
Add marginal transcript abundance inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This should take less than a minute to run and will create two files:
 
 #### Paths:
 
-The paths to be used for inference should be compressed and indexed using the [GBWT](https://github.com/jltsiren/gbwt). For transcriptome analyses a GBWT with transcript paths can be created using the `vg rna` subcommand in [vg](https://github.com/vgteam/vg). See [Transcriptomic analyses](https://github.com/vgteam/vg/wiki/Transcriptomic-analyses) wiki on the vg github for more information on how to use `vg rna`. 
+The pantranscriptome paths should be compressed and indexed using the [GBWT](https://github.com/jltsiren/gbwt). For transcriptome analyses a GBWT with transcript paths can be created using the `vg rna` subcommand in [vg](https://github.com/vgteam/vg). See [Transcriptomic analyses](https://github.com/vgteam/vg/wiki/Transcriptomic-analyses) wiki on the vg github for more information on how to use `vg rna`. 
 
 To decrease the computation time of rpvg it is recommended that a [r-index](https://github.com/jltsiren/gbwt/wiki/Fast-Locate) of the paths is supplied together with the GBWT index. The `vg gbwt` subcommand in vg can be used to construct the r-index from a GBWT index (see [VG GBWT Subcommand](https://github.com/vgteam/vg/wiki/VG-GBWT-Subcommand) wiki on the vg github). The name of the r-index should be the same as the GBWT index with an added *.ri* extension (e.g. *paths.gbwt.ri*).
 
@@ -51,11 +51,11 @@ The method currently contains four different inference models. Each model have b
 
 * `haplotypes`: Infers joint posterior probabilities of haplotype combinations (e.g. diplotypes). For diploid ploidy it uses a branch and bound like algorithm to infer the most probable combination of haplotypes. A faster, less accurate Gibbs sampling scheme can be enabled using `--use-hap-gibbs`, which scales much better for higher ploidies. The maximum ploidy can be given using `-y`.
 
-* `transcripts`: Infers abundances using a Expectation Maximization (EM) algorithm.
+* `transcripts`: Infers abundances using a Expectation Maximization (EM) algorithm. A file containing the transcript origin of each path in the pantranscriptome (`--write-info` output from `vg rna`) is needed to get transcript abundances if the pantranscriptome contains haplotype-specific transcripts. This can be given using `-f`. The haplotype probabilities are marginalized in the inference algorithm when this file is given.
 
 * `strains`: Infers abundances using a combination of weighted minimum path cover and EM. **Note that this algorithm has not yet been properly evaluated**.
 
-* `haplotype-transcripts`: Infers abundances using a combination of haplotype sampling and EM. The most probable haplotype combinations are inferred using the same algorithm as used in the `haplotypes` inference model. By default, equivalent haplotypes are inferred for all clustered transcripts, however independent inference of haplotypes for each transcript can be enabled using the `--ind-hap-inference` option. The inference algorithm requires a file (`-f`) containing the haplotype and transcript origin of each path (`--write-info` output from `vg rna`). 
+* `haplotype-transcripts`: Infers abundances using a combination of haplotype sampling and EM. The most probable haplotype combinations are inferred using the same algorithm as used in the `haplotypes` inference model. By default, equivalent haplotypes are inferred for all clustered transcripts, however independent inference of haplotypes for each transcript can be enabled using the `--ind-hap-inference` option. The inference algorithm requires a file (`-f`) containing the haplotype and transcript origin of each path in the pantranscriptome (`--write-info` output from `vg rna`). 
 
 #### Alignment types:
 

--- a/src/io/register_libvg_io.cpp
+++ b/src/io/register_libvg_io.cpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 /**
  * \file register_libvg_io.hpp
  * Includes calls to register all libvg types with libvgio.

--- a/src/io/register_libvg_io.hpp
+++ b/src/io/register_libvg_io.hpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 #ifndef VG_IO_REGISTER_LIBVG_IO_HPP_INCLUDED
 #define VG_IO_REGISTER_LIBVG_IO_HPP_INCLUDED
 

--- a/src/io/register_loader_saver_gbwt.cpp
+++ b/src/io/register_loader_saver_gbwt.cpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 /**
  * \file register_loader_saver_gbwt.cpp
  * Defines IO for a GBWT index from stream files.

--- a/src/io/register_loader_saver_gbwt.hpp
+++ b/src/io/register_loader_saver_gbwt.hpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 #ifndef VG_IO_REGISTER_LOADER_SAVER_GBWT_HPP_INCLUDED
 #define VG_IO_REGISTER_LOADER_SAVER_GBWT_HPP_INCLUDED
 

--- a/src/io/register_loader_saver_r_index.cpp
+++ b/src/io/register_loader_saver_r_index.cpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 /**
  * \file register_loader_saver_r_index.cpp
  * Defines IO for an r-index from stream files.

--- a/src/io/register_loader_saver_r_index.hpp
+++ b/src/io/register_loader_saver_r_index.hpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 #ifndef VG_IO_REGISTER_LOADER_SAVER_R_INDEX_HPP_INCLUDED
 #define VG_IO_REGISTER_LOADER_SAVER_R_INDEX_HPP_INCLUDED
 

--- a/src/io/register_loader_saver_xg.cpp
+++ b/src/io/register_loader_saver_xg.cpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 /**
  * \file register_loader_saver_xg.cpp
  * Defines IO for an XG index from stream files.

--- a/src/io/register_loader_saver_xg.hpp
+++ b/src/io/register_loader_saver_xg.hpp
@@ -1,3 +1,7 @@
+/*
+All the following code have been copied and modified from https://github.com/vgteam/vg
+*/
+
 #ifndef VG_IO_REGISTER_LOADER_SAVER_XG_HPP_INCLUDED
 #define VG_IO_REGISTER_LOADER_SAVER_XG_HPP_INCLUDED
 

--- a/src/path_clusters.cpp
+++ b/src/path_clusters.cpp
@@ -6,7 +6,7 @@
 #include "utils.hpp"
 
 
-static const uint32_t paths_per_mutex = 500;
+static const uint32_t paths_per_mutex = 100;
 static const uint32_t clusters_per_mutex = 100;
 
 PathClusters::PathClusters(const uint32_t num_threads_in, const PathsIndex & paths_index, const spp::sparse_hash_map<vector<AlignmentPath>, uint32_t> & align_paths_index) : num_threads(num_threads_in), num_paths(paths_index.numberOfPaths()) {

--- a/src/read_path_probabilities.hpp
+++ b/src/read_path_probabilities.hpp
@@ -27,8 +27,10 @@ class ReadPathProbabilities {
         double noiseProb() const;
         const vector<pair<double, vector<uint32_t> > > & pathProbs() const;
 
+        static vector<double> calcAlignPathLogProbs(const vector<AlignmentPath> & align_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end);
+
         void addReadCount(const uint32_t read_count_in);
-        void calcAlignPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob);
+        void addPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob, const bool collapse_groups = false, const spp::sparse_hash_map<string, uint32_t> & group_name_index = spp::sparse_hash_map<string, uint32_t>());
 
         bool quickMergeIdentical(const ReadPathProbabilities & probs_2);
 

--- a/src/tests/read_path_probabilities_test.cpp
+++ b/src/tests/read_path_probabilities_test.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 	paths.back().effective_length = 3;
 
 	ReadPathProbabilities read_path_probs(1, pow(10, -8));
-	read_path_probs.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+	read_path_probs.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 	REQUIRE(read_path_probs.readCount() == 1);
 	REQUIRE(Utils::doubleCompare(read_path_probs.noiseProb(), 0.1));
@@ -38,7 +38,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
     	alignment_paths.front().frag_length = 10000;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+		read_path_probs_2.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 		REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), read_path_probs.noiseProb()));
@@ -66,7 +66,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 		paths.back().effective_length = 3;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+		read_path_probs_2.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 		REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), read_path_probs.noiseProb()));
@@ -82,7 +82,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 			paths.back().effective_length = 2;
 
 			ReadPathProbabilities read_path_probs_3(1, 0.1);
-			read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+			read_path_probs_3.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 			REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 			REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), read_path_probs.noiseProb()));
@@ -101,7 +101,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 			alignment_path_ids.emplace_back(vector<gbwt::size_type>());
 
 			ReadPathProbabilities read_path_probs_3(1, 0.1);
-			read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+			read_path_probs_3.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 			REQUIRE(read_path_probs_3.readCount() == read_path_probs.readCount());
 			REQUIRE(Utils::doubleCompare(read_path_probs_3.noiseProb(), read_path_probs.noiseProb()));
@@ -120,7 +120,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 			alignment_path_ids.emplace_back(vector<gbwt::size_type>());
 
 			ReadPathProbabilities read_path_probs_3(1, 0.1);
-			read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+			read_path_probs_3.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 			REQUIRE(read_path_probs_3.readCount() == read_path_probs.readCount());
 			REQUIRE(Utils::doubleCompare(read_path_probs_3.noiseProb(), read_path_probs.noiseProb()));
@@ -138,7 +138,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
    		alignment_paths.back().score_sum = -2.302585 / Utils::noise_score_log_base;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+		read_path_probs_2.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 		REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.190000008369464));
@@ -150,7 +150,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 		alignment_paths.back().score_sum = 0;
 
 		ReadPathProbabilities read_path_probs_3(1, pow(10, -8));
-		read_path_probs_3.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+		read_path_probs_3.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 		REQUIRE(read_path_probs_3.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_3.noiseProb(), 1));
@@ -163,7 +163,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
 		paths.back().effective_length = 2;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
+		read_path_probs_2.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0);
 
 		REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), read_path_probs.noiseProb()));
@@ -180,7 +180,7 @@ TEST_CASE("Read path probabilities can be calculated from alignment paths") {
    		alignment_paths.back().score_sum = -5.0 / Utils::noise_score_log_base;
 
 		ReadPathProbabilities read_path_probs_2(1, pow(10, -8));
-		read_path_probs_2.calcAlignPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0.3);
+		read_path_probs_2.addPathProbs(alignment_paths, alignment_path_ids, clustered_path_index, paths, fragment_length_dist, false, 0.3);
 		
 		REQUIRE(read_path_probs_2.readCount() == read_path_probs.readCount());
 		REQUIRE(Utils::doubleCompare(read_path_probs_2.noiseProb(), 0.304716562899359));


### PR DESCRIPTION
Improvements:

* Adds ability to estimate the marginal transcript probabilities for haplotype-specific transcripts when using the *transcripts* inference model. This is enabled by providing a file containing the transcript origin of each path in the pantranscriptome using `-f`.  