### PR TITLE
Update libvgio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/deps/gbwt/include
   ${PROJECT_SOURCE_DIR}/deps/libvgio
   ${PROJECT_SOURCE_DIR}/deps/libvgio/include
-  ${PROJECT_SOURCE_DIR}/deps/libvgio/handlegraph-prefix/include
+  ${PROJECT_SOURCE_DIR}/deps/libvgio/deps/libhandlegraph/src/include
   ${PROJECT_SOURCE_DIR}/deps/eigen
   ${PROJECT_SOURCE_DIR}/deps/xg/src
   ${PROJECT_SOURCE_DIR}/deps/xg/deps/mmmulti/src
@@ -85,7 +85,7 @@ link_directories(
   ${PROJECT_SOURCE_DIR}/deps/sdsl-lite/lib
   ${PROJECT_SOURCE_DIR}/deps/gbwt/lib
   ${PROJECT_SOURCE_DIR}/deps/libvgio
-  ${PROJECT_SOURCE_DIR}/deps/libvgio/handlegraph-prefix/lib
+  ${PROJECT_SOURCE_DIR}/deps/libvgio/deps/libhandlegraph
 )
 
 add_library(xg 


### PR DESCRIPTION
This should add support for GAM files generated by `vg giraffe`, which have extra metadata chunks embedded in them that need a newer libvgio to parse.

It also fixes the build for me; the CMakeLists.txt seemed to expect a `handlegraph-prefix` directory to exist, but never seemed to actually populate it. (Maybe the old libhandlegraph CMake would do it?)

(In general `libvgio` probably wants to be an `add_subdirectory()` dependency and not an `ExternalProject_Add()` dependency, because then you get all the libvgio CMake targets available to just link against.)

I've tested the normal and static builds (though you need to delete your CMake build directory when switching between them or `PROTOBUF_LIBRARIES` won't change from the .so to the .a). The normal build works, and the static build seems like it *would* work if I had a static `libhtscodecs` available on the machine, which `pkg-config --static --libs htslib` asks for but which doesn't actually exist.