### PR TITLE
Support finding haplotype matches that are partial/internal at both the start and the end

### DIFF
--- a/src/alignment_path.cpp
+++ b/src/alignment_path.cpp
@@ -13,34 +13,28 @@ AlignmentPath::AlignmentPath(const AlignmentSearchPath & align_path_in, const bo
 vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const vector<AlignmentSearchPath> & align_search_paths, const bool is_multimap, const uint8_t min_mapq) {
 
     if (align_search_paths.empty()) {
-        std::cerr << "There are no alignment paths because there are no alignment search paths." << std::endl;
         return vector<AlignmentPath>();
     }
 
     bool is_simple = !is_multimap;
 
     if (is_simple) {
-        std::cerr << "Simple case." << std::endl;
 
         uint32_t frag_length = 0;
 
         for (auto & align_search_path: align_search_paths) {
 
             if (align_search_path.isComplete()) {
-                std::cerr << "Found a complete alignment search path." << std::endl;
 
                 assert(!align_search_path.gbwt_search.first.empty());
 
                 if (align_search_path.isInternal() || (frag_length > 0 && align_search_path.fragmentLength() != frag_length)) {
-                    std::cerr << "Actually, this isn't the simple case." << std::endl;
                     is_simple = false;
                     break;
                 } 
 
                 frag_length = align_search_path.fragmentLength();
                 assert(frag_length > 0);
-            } else {
-                std::cerr << "Found an incomplete alignment search path." << std::endl;
             }
         }
     }
@@ -53,12 +47,9 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
 
     double noise_prob = 1;
 
-    std::cerr << "Complex case." << std::endl;
-
     for (auto & align_search_path: align_search_paths) {
 
         if (align_search_path.gbwt_search.first.empty()) {
-            std::cerr << "Found an alignment search path with an empty search state; we couldn't find the path for this fragment. Treating as a noise match." << std::endl;
 
             assert(align_search_path.insert_length == 0);
             assert(!align_search_path.read_align_stats.empty());
@@ -77,20 +68,14 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
             noise_prob = min(noise_prob, 1 - non_noise_prob);
 
         } else if (align_search_path.isComplete()) {
-            std::cerr << "Found a complete alignment search path; creating an alignment path." << std::endl;
-                
             align_paths.emplace_back(align_search_path, is_simple, min_mapq);
             assert(align_paths.front().min_mapq == align_paths.back().min_mapq);
-        } else {
-            std::cerr << "Found an incomplete but nonempty alignment search path; ignoring." << std::endl;
         }
     }
 
     sort(align_paths.rbegin(), align_paths.rend());
 
     if (!align_paths.empty()) {
-
-        std::cerr << "Creating a noise option for fragment with " << align_paths.size() << " non-noise options." << std::endl;
 
         if (Utils::doubleCompare(noise_prob, 0)) {
 

--- a/src/alignment_path.cpp
+++ b/src/alignment_path.cpp
@@ -58,7 +58,7 @@ vector<AlignmentPath> AlignmentPath::alignmentSearchPathsToAlignmentPaths(const 
     for (auto & align_search_path: align_search_paths) {
 
         if (align_search_path.gbwt_search.first.empty()) {
-            std::cerr << "Found an alignment search path with an empty search state; we couldn't find the path for this fragment. Treating as a noise read." << std::endl;
+            std::cerr << "Found an alignment search path with an empty search state; we couldn't find the path for this fragment. Treating as a noise match." << std::endl;
 
             assert(align_search_path.insert_length == 0);
             assert(!align_search_path.read_align_stats.empty());

--- a/src/alignment_path.hpp
+++ b/src/alignment_path.hpp
@@ -15,6 +15,10 @@ using namespace std;
 
 class AlignmentSearchPath;
 
+/**
+ * Represents the result of a completed search for a read or read pair in the
+ * GBWT.
+ */
 class AlignmentPath {
 
     public: 
@@ -88,7 +92,11 @@ bool operator<(const InternalAlignment & lhs, const InternalAlignment & rhs);
 
 ostream & operator<<(ostream & os, const InternalAlignment & read_align_stats);
 
-
+/**
+ * Represents an individual Alignment or linearization of an individual
+ * MultipathAlignment within a fragment, while searching for a path in the GBWT
+ * that the fragment could have come from.
+ */
 class AlignmentStats {
 
     public: 
@@ -128,13 +136,19 @@ bool operator<(const AlignmentStats & lhs, const AlignmentStats & rhs);
 
 ostream & operator<<(ostream & os, const AlignmentStats & read_align_stats);
 
-
+/**
+ * Represents an intermediate state in searching for the path taken by a single
+ * read or read pair's Alignment(s), or one of the paths consistent with the
+ * MultipathAlignment(s), in the GBWT. (So this belongs to a fragment and not
+ * an individual alignment.)
+ */
 class AlignmentSearchPath {
 
     public: 
     
         AlignmentSearchPath();
-
+        
+        /// This holds the full path that the fragment came from.
         vector<gbwt::node_type> path;
         pair<gbwt::SearchState, gbwt::size_type> gbwt_search;
 
@@ -142,7 +156,8 @@ class AlignmentSearchPath {
         uint32_t end_offset;
 
         int32_t insert_length;
-
+        
+        /// This holds the per-read statistic values within the fragment.
         vector<AlignmentStats> read_align_stats;
 
         uint32_t alignmentLength() const;

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -262,10 +262,8 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
     // We keep our search paths organized with the full-length search first,
     // then any partial searches starting at progressively later points. If we
     // are near enough to the end to have partial-at-the-end paths, we start
-    // appending shorter partial-at-the-end search paths.
-    //
-    // TODO: Should we keep the searches sorted by start position to improve
-    // the "main" path finding?
+    // appending shorter partial-at-the-end search paths interleaved with any
+    // partial-at-the-start paths that start that late.
 
     if (is_first_path) {
 

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -113,7 +113,6 @@ uint32_t AlignmentPathFinder<AlignmentType>::mappingQuality(const AlignmentType 
     }
 }
 
-#define debug
 template<class AlignmentType>
 vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(const AlignmentType & alignment) const {
 
@@ -125,14 +124,16 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 #endif
 
     if (!alignmentHasPath(alignment)) {
-
+#ifdef debug
         std::cerr << "Alignment is unaligned because it does not have a path" << std::endl;
+#endif
         return vector<AlignmentPath>();
     }
 
     if (!alignmentStartInGraph(alignment)) {
-
+#ifdef debug
         std::cerr << "Alignment is unaligned because its start location is not in the graph" << std::endl;
+#endif
         return vector<AlignmentPath>();
     }
 
@@ -160,12 +161,15 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
             findAlignmentSearchPaths(&align_search_paths, alignment_rc);
         }  
     }
-
+#ifdef debug
     std::cerr << "Alignment has " << align_search_paths.size() << " search paths in " << library_type << " library" << std::endl;
+#endif
 
     auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths, isAlignmentDisconnected(alignment), mappingQuality(alignment));
 
+#ifdef debug
     std::cerr << "Alignment has " << align_paths.size() << " alignment paths" << std::endl;
+#endif
 
 #ifdef debug
 
@@ -178,7 +182,6 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 
     return align_paths;
 }
-#undef debug
 
 template<class AlignmentType>
 vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const {
@@ -282,7 +285,11 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
     // As we exhaust all results for earlier search paths, we advance this so we no longer have to consider them.
     uint32_t first_main_idx = 0;
 
-    std::cerr << "Extending search of " << align_search_paths->front().path.size() << " nodes and " << align_search_paths->front().gbwt_search.first.size() << " results with " << path.mapping_size() << " more mappings" << std::endl;
+#ifdef debug
+    std::cerr << "Extending search of " << align_search_paths->front().path.size() << " nodes and "
+        << align_search_paths->front().gbwt_search.first.size() << " results with " 
+        << path.mapping_size() << " more mappings" << std::endl;
+#endif
 
     auto mapping_it = path.mapping().cbegin();
     assert(mapping_it != path.mapping().cend());
@@ -291,8 +298,12 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
     --end_mapping_it;
 
     while (mapping_it != path.mapping().cend()) {
-
-        std::cerr << "Consider mapping to " << mapping_it->position().node_id() << (mapping_it->position().is_reverse() ? "-" : "+")  << " with " << align_search_paths->size() << " search paths in progress" << std::endl;
+        
+#ifdef debug
+        std::cerr << "Consider mapping to " << mapping_it->position().node_id() 
+            << (mapping_it->position().is_reverse() ? "-" : "+")  << " with " << align_search_paths->size() 
+            << " search paths in progress" << std::endl;
+#endif
 
         auto cur_node = Utils::mapping_to_gbwt(*mapping_it);
         auto mapping_read_length = Utils::mapping_to_length(*mapping_it);
@@ -315,8 +326,12 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
                 auto& candidate = align_search_paths->at(first_main_idx);
 
                 if (candidate.gbwt_search.first.empty()) {
-                    std::cerr << "Main path candidate " << first_main_idx << " has run out of results so we can't use it" << std::endl;
-                    std::cerr << "Skipped candidate main search of " << candidate.path.size() << " nodes and " << candidate.gbwt_search.first.size() << " results" << std::endl;
+#ifdef debug
+                    std::cerr << "Main path candidate " << first_main_idx 
+                        << " has run out of results so we can't use it" << std::endl;
+                    std::cerr << "Skipped candidate main search of " << candidate.path.size() 
+                        << " nodes and " << candidate.gbwt_search.first.size() << " results" << std::endl;
+#endif
                     continue;
                 }
 
@@ -324,8 +339,12 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
                 // search here and using those results. 
                 
                 if (candidate.read_align_stats.back().internal_end.is_internal) {
-                    std::cerr << "Main path candidate " << first_main_idx << " is already internal at the end" << std::endl;
-                    std::cerr << "Skipped candidate main search of " << candidate.path.size() << " nodes and " << candidate.gbwt_search.first.size() << " results" << std::endl;
+#ifdef debug
+                    std::cerr << "Main path candidate " << first_main_idx 
+                        << " is already internal at the end" << std::endl;
+                    std::cerr << "Skipped candidate main search of " << candidate.path.size() 
+                        << " nodes and " << candidate.gbwt_search.first.size() << " results" << std::endl;
+#endif
                     continue;
                 }
 
@@ -354,21 +373,33 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
                     // sequence left can decrease; this isn't permanent. So we
                     // need to not adopt anything as the main search, but to
                     // check back here next time to see if it is in range.
-                    std::cerr << "Main path candidate " << first_main_idx << " has too much sequence left (" << seq_length - candidate.read_align_stats.back().length <<  ") vs. max end offset " << candidate.read_align_stats.back().internal_end.max_offset << std::endl;
+
+#ifdef debug
+                    std::cerr << "Main path candidate " << first_main_idx 
+                        << " has too much sequence left (" << seq_length - candidate.read_align_stats.back().length 
+                        <<  ") vs. max end offset " << candidate.read_align_stats.back().internal_end.max_offset << std::endl;
+#endif
+
                 }
 
                 break;
             }
         }
         
+#ifdef debug
         if (!main_align_search_path.gbwt_search.first.empty()) {
-            std::cerr << "Selected main search " << first_main_idx << "/" << align_search_paths->size() << " of " << main_align_search_path.path.size() << " nodes and " << main_align_search_path.gbwt_search.first.size() << " results" << std::endl;
+            std::cerr << "Selected main search " << first_main_idx << "/" << align_search_paths->size() 
+                << " of " << main_align_search_path.path.size() << " nodes and " 
+                << main_align_search_path.gbwt_search.first.size() << " results" << std::endl;
         }
+#endif
 
         for (auto & align_search_path: *align_search_paths) {
 
             if (align_search_path.read_align_stats.back().internal_end.is_internal) {
+#ifdef debug
                 std::cerr << "Consider internal search path" << std::endl;
+#endif
 
                 assert(max_partial_offset > 0);
 
@@ -384,18 +415,24 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
                 internal_end_read_align_stats->internal_end.offset += internal_end_new_offset;
 
                 if (internal_end_read_align_stats->internal_end.offset <= max_partial_offset) {
+#ifdef debug
                     std::cerr << "Keep internal search path" << std::endl;
+#endif
                     
                     internal_end_read_align_stats->internal_end.penalty += alignmentScore(quality, internal_end_read_align_stats->length, internal_end_new_offset);
                 
                 } else {
+#ifdef debug
                     std::cerr << "Clear out internal search path" << std::endl;
+#endif
 
                     align_search_path.clear();
                 }
             
             } else {
+#ifdef debug
                 std::cerr << "Consider extending search path " << &align_search_path - &align_search_paths->at(0) << std::endl;
+#endif
 
                 extendAlignmentSearchPath(&align_search_path, *mapping_it);
             }
@@ -439,7 +476,9 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
                     main_align_search_path.read_align_stats.back().internal_end_next_node = cur_node;
                     main_align_search_path.read_align_stats.back().internal_end.penalty = alignmentScore(quality, main_align_search_path.read_align_stats.back().length, main_align_search_path.read_align_stats.back().internal_end.offset);
 
+#ifdef debug
                     std::cerr << "Start new partial search path from nonempty main search result set" << std::endl;
+#endif
                     align_search_paths->emplace_back(main_align_search_path);
                 }
             }
@@ -457,7 +496,9 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
 
                 if (internal_start_read_align_stats.internal_start.offset <= max_partial_offset) {
 
+#ifdef debug
                     std::cerr << "Consider starting new partial search path from scratch, vs. path " << last_internal_start_idx << std::endl;
+#endif
                     AlignmentSearchPath new_start_align_search_path;
                     extendAlignmentSearchPath(&new_start_align_search_path, *mapping_it);
 
@@ -467,7 +508,11 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
 
                         if (new_start_align_search_path.gbwt_search.first.size() > align_search_paths->at(last_internal_start_idx).gbwt_search.first.size()) {
 
-                            std::cerr << "Found more results (" << new_start_align_search_path.gbwt_search.first.size() << " > " << align_search_paths->at(last_internal_start_idx).gbwt_search.first.size() << "), so starting new partial search path" << std::endl;
+#ifdef debug
+                            std::cerr << "Found more results (" << new_start_align_search_path.gbwt_search.first.size() 
+                                << " > " << align_search_paths->at(last_internal_start_idx).gbwt_search.first.size() 
+                                << "), so starting new partial search path" << std::endl;
+#endif
 
                             align_search_paths->emplace_back(new_start_align_search_path);
                             last_internal_start_idx = align_search_paths->size() - 1;
@@ -492,19 +537,27 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
 template<class AlignmentType>
 void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(AlignmentSearchPath * align_search_path, const vg::Mapping & mapping) const {
 
-    std::cerr << "Extend alignment search path of " << align_search_path->path.size() << " nodes and " << align_search_path->gbwt_search.first.size() << " results with visit to " << mapping.position().node_id() << (mapping.position().is_reverse() ? "-" : "+") << std::endl;
+#ifdef debug
+    std::cerr << "Extend alignment search path of " << align_search_path->path.size() 
+        << " nodes and " << align_search_path->gbwt_search.first.size() 
+        << " results with visit to " << mapping.position().node_id() << (mapping.position().is_reverse() ? "-" : "+") << std::endl;
+#endif
 
     auto cur_node = Utils::mapping_to_gbwt(mapping);
 
     if (align_search_path->path.empty()) {
+#ifdef debug
         std::cerr << "Nothing searched yet, search this visit" << std::endl;
+#endif
 
         assert(align_search_path->gbwt_search.first.node == gbwt::ENDMARKER);
 
         align_search_path->path.emplace_back(cur_node);
         paths_index.find(&(align_search_path->gbwt_search), cur_node);
 
+#ifdef debug
         std::cerr << "Searching visit found " << align_search_path->gbwt_search.first.size() << " results" << std::endl;
+#endif
   
         align_search_path->start_offset = mapping.position().offset();
 
@@ -519,7 +572,9 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(AlignmentSear
 
         if (is_cycle_visit && mapping.position().offset() != 0) {
 
+#ifdef debug
             std::cerr << "Attempting to enter the same node again not at its start! Maybe mappings aren't simplified? Clearing search path!" << std::endl;
+#endif
 
             align_search_path->clear();
 
@@ -529,15 +584,20 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(AlignmentSear
 
             if (!align_search_path->gbwt_search.first.empty()) {
 
+#ifdef debug
                 std::cerr << "Have " << align_search_path->gbwt_search.first.size() << " results before extension" << std::endl;
+#endif
 
                 paths_index.extend(&(align_search_path->gbwt_search), cur_node);
 
+#ifdef debug
                 std::cerr << "Have " << align_search_path->gbwt_search.first.size() << " results after extension" << std::endl;
+#endif
 
             } else {
+#ifdef debug
                 std::cerr << "Not extending already-empty search state" << std::endl;
-
+#endif
             }
         } 
     }

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -359,14 +359,10 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
 
                 break;
             }
-        } else {
-            std::cerr << "Not looking for a main search" << std::endl;
         }
         
         if (!main_align_search_path.gbwt_search.first.empty()) {
             std::cerr << "Selected main search " << first_main_idx << "/" << align_search_paths->size() << " of " << main_align_search_path.path.size() << " nodes and " << main_align_search_path.gbwt_search.first.size() << " results" << std::endl;
-        } else {
-            std::cerr << "Selected no main search." << std::endl;
         }
 
         for (auto & align_search_path: *align_search_paths) {
@@ -478,20 +474,10 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
 
                             internal_start_read_align_stats.internal_start.penalty = alignmentScore(quality, internal_start_read_align_stats.left_softclip_length, internal_start_read_align_stats.internal_start.offset);
                             align_search_paths->back().read_align_stats = vector<AlignmentStats>(1, internal_start_read_align_stats);
-                        } else {
-                            std::cerr << "Found no more results (" << new_start_align_search_path.gbwt_search.first.size() << " <= " << align_search_paths->at(last_internal_start_idx).gbwt_search.first.size() << ")." << std::endl;
                         }
-                    } else {
-                        std::cerr << "Found no results." << std::endl;
                     }
-                } else {
-                    std::cerr << "Read align stats out of range to start new search (" << internal_start_read_align_stats.internal_start.offset << " > " << max_partial_offset << ")" << std::endl;
                 }
-            } else {
-                std::cerr << "Out of range to start new search (" << align_search_paths->at(last_internal_start_idx).read_align_stats.back().length << " > " << align_search_paths->at(last_internal_start_idx).read_align_stats.back().internal_start.max_offset << ")" << std::endl;
             }
-        } else {
-            std::cerr << "Not supposed to start new internal search; last is " << last_internal_start_idx << std::endl;
         }
 
         for (auto & align_search_path: *align_search_paths) {

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -279,8 +279,10 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(vector<Alignm
     // internal to the read, on its left. 
     uint32_t last_internal_start_idx = 0;
 
-    // This is the first path that we could possibly use as out "main" path for making partial-at-the-end paths.
-    // As we exhaust all results for earlier search paths, we advance this so we no longer have to consider them.
+    // This is the first path that we could possibly use as out "main" path for
+    // making partial-at-the-end paths. As we exhaust all results for earlier
+    // search paths, we advance this so we no longer have to consider them. (We
+    // also always use the first "main" path we could use.)
     uint32_t first_main_idx = 0;
 
 #ifdef debug

--- a/src/alignment_path_finder.cpp
+++ b/src/alignment_path_finder.cpp
@@ -113,6 +113,7 @@ uint32_t AlignmentPathFinder<AlignmentType>::mappingQuality(const AlignmentType 
     }
 }
 
+#define debug
 template<class AlignmentType>
 vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(const AlignmentType & alignment) const {
 
@@ -125,11 +126,13 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 
     if (!alignmentHasPath(alignment)) {
 
+        std::cerr << "Alignment is unaligned because it does not have a path" << std::endl;
         return vector<AlignmentPath>();
     }
 
     if (!alignmentStartInGraph(alignment)) {
 
+        std::cerr << "Alignment is unaligned because its start location is not in the graph" << std::endl;
         return vector<AlignmentPath>();
     }
 
@@ -158,7 +161,11 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
         }  
     }
 
+    std::cerr << "Alignment has " << align_search_paths.size() << " search paths in " << library_type << " library" << std::endl;
+
     auto align_paths = AlignmentPath::alignmentSearchPathsToAlignmentPaths(align_search_paths, isAlignmentDisconnected(alignment), mappingQuality(alignment));
+
+    std::cerr << "Alignment has " << align_paths.size() << " alignment paths" << std::endl;
 
 #ifdef debug
 
@@ -171,6 +178,7 @@ vector<AlignmentPath> AlignmentPathFinder<AlignmentType>::findAlignmentPaths(con
 
     return align_paths;
 }
+#undef debug
 
 template<class AlignmentType>
 vector<AlignmentSearchPath> AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPath(const AlignmentSearchPath & align_search_path, const vg::Alignment & alignment) const {
@@ -618,7 +626,7 @@ void AlignmentPathFinder<AlignmentType>::extendAlignmentSearchPaths(vector<Align
                 assert(!align_search_path.read_align_stats.back().complete);
 
                 align_search_path.read_align_stats.back().complete = true;
-                align_search_paths->emplace_back(move(align_search_path));
+                align_search_paths->emplace_back(std::move(align_search_path));
             }
         }
     }
@@ -741,7 +749,7 @@ void AlignmentPathFinder<AlignmentType>::findAlignmentSearchPaths(vector<Alignme
             joint_single_align_score = Utils::add_log(joint_single_align_score, score_sum * Utils::score_log_base);
         }
 
-        align_search_paths->emplace_back(move(single_search_path));
+        align_search_paths->emplace_back(std::move(single_search_path));
     }
 
     align_search_paths->emplace_back(AlignmentSearchPath());

--- a/src/path_abundance_estimator.cpp
+++ b/src/path_abundance_estimator.cpp
@@ -278,7 +278,7 @@ void MinimumPathAbundanceEstimator::estimate(PathClusterEstimates * path_cluster
                 gibbsReadCountSampler(&min_path_cluster_estimates, min_path_read_path_probs, min_path_read_counts, abundance_gibbs_gamma, mt_rng, num_gibbs_samples);
 
                 assert(min_path_cluster_estimates.gibbs_read_count_samples.size() == 1);
-                path_cluster_estimates->gibbs_read_count_samples.emplace_back(move(min_path_cluster_estimates.gibbs_read_count_samples.front()));
+                path_cluster_estimates->gibbs_read_count_samples.emplace_back(std::move(min_path_cluster_estimates.gibbs_read_count_samples.front()));
             }
 
             assert(min_path_cluster_estimates.abundances.size() == min_path_cover.size());
@@ -692,7 +692,7 @@ void NestedPathAbundanceEstimator::inferPathSubsetAbundance(PathClusterEstimates
                 gibbsReadCountSampler(&subset_path_cluster_estimates, subset_read_path_probs, subset_read_counts, abundance_gibbs_gamma, mt_rng, cur_subset_gibbs_samples);
 
                 assert(subset_path_cluster_estimates.gibbs_read_count_samples.size() == 1);
-                path_cluster_estimates->gibbs_read_count_samples.emplace_back(move(subset_path_cluster_estimates.gibbs_read_count_samples.front()));
+                path_cluster_estimates->gibbs_read_count_samples.emplace_back(std::move(subset_path_cluster_estimates.gibbs_read_count_samples.front()));
             }
         }
 

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -73,6 +73,8 @@ void ReadPathProbabilities::addReadCount(const uint32_t read_count_in) {
 
 void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob, const bool collapse_groups, const spp::sparse_hash_map<string, uint32_t> & group_name_index) {
 
+    std::cerr << "Add path probabilities for " << align_paths.size() << " AlignemntPaths vs. " << cluster_paths.size() << " PathInfos" << std::endl;
+
     assert(align_paths.size() > 1);
     assert(align_paths.size() == align_paths_ids.size());
     assert(clustered_path_index.size() == cluster_paths.size());
@@ -80,6 +82,7 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
     assert(path_probs.empty());
 
     if (align_paths.front().min_mapq > 0) {
+        std::cerr << "Best alignment has nonzero MAPQ" << std::endl;
 
         noise_prob = max(prob_precision, max(min_noise_prob, Utils::phred_to_prob(align_paths.front().min_mapq)));
         assert(noise_prob < 1 && noise_prob > 0);
@@ -132,6 +135,8 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
                         read_path_log_probs.at(path_idx) = max(read_path_log_probs.at(path_idx), log_prob);
                     }
                 }
+
+                std::cerr << "read_path_log_probs[" << path_idx << "] = " << read_path_log_probs.at(path_idx) << std::endl;
             }
         }
 
@@ -206,6 +211,8 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
         noise_prob += low_prob_sum * (1 - noise_prob);
 
         sort(path_probs.begin(), path_probs.end());
+    } else {
+        std::cerr << "Nothing has nonzero MAPQ" << std::endl;
     }
 }
 

--- a/src/read_path_probabilities.cpp
+++ b/src/read_path_probabilities.cpp
@@ -73,7 +73,9 @@ void ReadPathProbabilities::addReadCount(const uint32_t read_count_in) {
 
 void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_paths, const vector<vector<gbwt::size_type> > & align_paths_ids, const spp::sparse_hash_map<uint32_t, uint32_t> & clustered_path_index, const vector<PathInfo> & cluster_paths, const FragmentLengthDist & fragment_length_dist, const bool is_single_end, const double min_noise_prob, const bool collapse_groups, const spp::sparse_hash_map<string, uint32_t> & group_name_index) {
 
+#ifdef debug
     std::cerr << "Add path probabilities for " << align_paths.size() << " AlignemntPaths vs. " << cluster_paths.size() << " PathInfos" << std::endl;
+#endif
 
     assert(align_paths.size() > 1);
     assert(align_paths.size() == align_paths_ids.size());
@@ -82,7 +84,9 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
     assert(path_probs.empty());
 
     if (align_paths.front().min_mapq > 0) {
+#ifdef debug
         std::cerr << "Best alignment has nonzero MAPQ" << std::endl;
+#endif
 
         noise_prob = max(prob_precision, max(min_noise_prob, Utils::phred_to_prob(align_paths.front().min_mapq)));
         assert(noise_prob < 1 && noise_prob > 0);
@@ -136,7 +140,9 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
                     }
                 }
 
+#ifdef debug
                 std::cerr << "read_path_log_probs[" << path_idx << "] = " << read_path_log_probs.at(path_idx) << std::endl;
+#endif
             }
         }
 
@@ -211,8 +217,6 @@ void ReadPathProbabilities::addPathProbs(const vector<AlignmentPath> & align_pat
         noise_prob += low_prob_sum * (1 - noise_prob);
 
         sort(path_probs.begin(), path_probs.end());
-    } else {
-        std::cerr << "Nothing has nonzero MAPQ" << std::endl;
     }
 }
 

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -2545,8 +2545,9 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     gbwt::vector_type gbwt_thread_1(8);
     gbwt::vector_type gbwt_thread_2(8);
     gbwt::vector_type gbwt_thread_3(8);
+    gbwt::vector_type gbwt_thread_4(8);
     
-    // This agrees with the alignment from 1 bp in on the start and 4 bp in on the end
+    // This agrees with the alignment from 2 bp in on the start and 4 bp in on the end
     gbwt_thread_1[0] = gbwt::Node::encode(1, false);
     gbwt_thread_1[1] = gbwt::Node::encode(2, false);
     gbwt_thread_1[2] = gbwt::Node::encode(5, false);
@@ -2556,7 +2557,7 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     gbwt_thread_1[6] = gbwt::Node::encode(9, false);
     gbwt_thread_1[7] = gbwt::Node::encode(11, false);
     
-    // This agrees with the alignment from 1 bp in on the start, and all the way to the end
+    // This agrees with the alignment from 2 bp in on the start, and all the way to the end
     gbwt_thread_2[0] = gbwt::Node::encode(1, false);
     gbwt_thread_2[1] = gbwt::Node::encode(2, false);
     gbwt_thread_2[2] = gbwt::Node::encode(5, false);
@@ -2566,19 +2567,30 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     gbwt_thread_2[6] = gbwt::Node::encode(10, false);
     gbwt_thread_2[7] = gbwt::Node::encode(11, false);
 
-    // This agrees with the alignment all the way through
+    // This agrees with the alignment from the very start up to 4 bp in on the end
     gbwt_thread_3[0] = gbwt::Node::encode(1, false);
     gbwt_thread_3[1] = gbwt::Node::encode(3, false);
     gbwt_thread_3[2] = gbwt::Node::encode(5, false);
     gbwt_thread_3[3] = gbwt::Node::encode(6, false);
     gbwt_thread_3[4] = gbwt::Node::encode(7, false);
     gbwt_thread_3[5] = gbwt::Node::encode(8, false);
-    gbwt_thread_3[6] = gbwt::Node::encode(10, false);
+    gbwt_thread_3[6] = gbwt::Node::encode(9, false);
     gbwt_thread_3[7] = gbwt::Node::encode(11, false);
+
+    // This agrees with the alignment all the way through
+    gbwt_thread_4[0] = gbwt::Node::encode(1, false);
+    gbwt_thread_4[1] = gbwt::Node::encode(3, false);
+    gbwt_thread_4[2] = gbwt::Node::encode(5, false);
+    gbwt_thread_4[3] = gbwt::Node::encode(6, false);
+    gbwt_thread_4[4] = gbwt::Node::encode(7, false);
+    gbwt_thread_4[5] = gbwt::Node::encode(8, false);
+    gbwt_thread_4[6] = gbwt::Node::encode(10, false);
+    gbwt_thread_4[7] = gbwt::Node::encode(11, false);
 
     gbwt_builder.insert(gbwt_thread_1, false);
     gbwt_builder.insert(gbwt_thread_2, false);
     gbwt_builder.insert(gbwt_thread_3, false);
+    gbwt_builder.insert(gbwt_thread_4, false);
 
     gbwt_builder.finish();
 
@@ -2654,7 +2666,7 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     PathsIndex paths_index(gbwt_index, r_index, graph);
     
     REQUIRE(!paths_index.bidirectional());
-    REQUIRE(paths_index.numberOfPaths() == 3);
+    REQUIRE(paths_index.numberOfPaths() == 4);
 
     SECTION("Unpaired single-path read alignment with a 0 bp partial match limit finds only the exact match path and the noise option") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
@@ -2662,8 +2674,8 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
         REQUIRE(alignment_paths.size() == 2);
     }
 
-    SECTION("Unpaired single-path read alignment with a 1 bp partial match limit also finds path that differs by 1 bp at the start") {
-        AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 1, true, 20, 0);
+    SECTION("Unpaired single-path read alignment with a 2 bp partial match limit also finds path that differs by 2 bp at the start") {
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 2, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 3);
     }
@@ -2674,7 +2686,7 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
         REQUIRE(alignment_paths.size() == 3);
     }
 
-    SECTION("Unpaired single-path read alignment with 4 bp partial match limit also finds the path that differs by 4 bp at the end") {
+    SECTION("Unpaired single-path read alignment with 4 bp partial match limit also finds the path that differs by 4 bp at the end but not the one that differs at both the start and end") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 4, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 4);
@@ -2881,7 +2893,7 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
 
     gbwt::vector_type gbwt_thread_1(8);
     
-    // This agrees with the alignment from 1 bp in on the start and 4 bp in on the end
+    // This agrees with the alignment from 2 bp in on the start and 4 bp in on the end
     gbwt_thread_1[0] = gbwt::Node::encode(1, false);
     gbwt_thread_1[1] = gbwt::Node::encode(2, false);
     gbwt_thread_1[2] = gbwt::Node::encode(5, false);

--- a/src/tests/alignment_path_finder_test.cpp
+++ b/src/tests/alignment_path_finder_test.cpp
@@ -2656,25 +2656,25 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 3);
 
-    SECTION("Unapired single-path read alignment with a 0 bp partial match limit finds only the exact match path and the noise option") {
+    SECTION("Unpaired single-path read alignment with a 0 bp partial match limit finds only the exact match path and the noise option") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 2);
     }
 
-    SECTION("Unapired single-path read alignment with a 1 bp partial match limit also finds path that differs by 1 bp at the start") {
+    SECTION("Unpaired single-path read alignment with a 1 bp partial match limit also finds path that differs by 1 bp at the start") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 1, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 3);
     }
 
-    SECTION("Unapired single-path read alignment with 3 bp partial match limit finds no more paths") {
+    SECTION("Unpaired single-path read alignment with 3 bp partial match limit finds no more paths") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 3, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 3);
     }
 
-    SECTION("Unapired single-path read alignment with 4 bp partial match limit also finds the path that differs by 4 bp at the end") {
+    SECTION("Unpaired single-path read alignment with 4 bp partial match limit also finds the path that differs by 4 bp at the end") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 4, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 4);
@@ -2816,20 +2816,20 @@ TEST_CASE("Partial alignment path(s) can be found on the end from an unpaired si
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 1);
 
-    SECTION("Unapired single-path read alignment with a 0 bp partial match limit finds no options") {
+    SECTION("Unpaired single-path read alignment with a 0 bp partial match limit finds no options") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         // If there are no real options, we don't create a noise option.
         REQUIRE(alignment_paths.size() == 0);
     }
 
-    SECTION("Unapired single-path read alignment with 3 bp partial match limit finds no more paths") {
+    SECTION("Unpaired single-path read alignment with 3 bp partial match limit finds no more paths") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 3, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 0);
     }
 
-    SECTION("Unapired single-path read alignment with 8 bp partial match limit finds the path that differs by 4 bp at the end, and a noise option") {
+    SECTION("Unpaired single-path read alignment with 8 bp partial match limit finds the path that differs by 4 bp at the end, and a noise option") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 8, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 2);
@@ -2880,8 +2880,6 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     gbwt::GBWTBuilder gbwt_builder(gbwt::bit_length(gbwt::Node::encode(10, true)));
 
     gbwt::vector_type gbwt_thread_1(8);
-    gbwt::vector_type gbwt_thread_2(8);
-    gbwt::vector_type gbwt_thread_3(8);
     
     // This agrees with the alignment from 1 bp in on the start and 4 bp in on the end
     gbwt_thread_1[0] = gbwt::Node::encode(1, false);
@@ -2971,20 +2969,26 @@ TEST_CASE("Partial alignment path(s) can be found on the start and end from an u
     REQUIRE(!paths_index.bidirectional());
     REQUIRE(paths_index.numberOfPaths() == 1);
 
-    SECTION("Unapired single-path read alignment with a 0 bp partial match limit finds no options") {
+    SECTION("Unpaired single-path read alignment with a 0 bp partial match limit finds no options") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 0, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         // If there are no real options, we don't create a noise option.
         REQUIRE(alignment_paths.size() == 0);
     }
 
-    SECTION("Unapired single-path read alignment with 3 bp partial match limit finds no more paths") {
+    SECTION("Unpaired single-path read alignment with 3 bp partial match limit finds no more paths") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 3, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 0);
     }
 
-    SECTION("Unapired single-path read alignment with 8 bp partial match limit finds the path that differs by 4 bp at the end, and a noise option") {
+    SECTION("Unpaired single-path read alignment with 4 bp partial match limit finds the path that differs by 4 bp at the end, and a noise option") {
+        AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 4, true, 20, 0);
+        auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
+        REQUIRE(alignment_paths.size() == 2);
+    }
+
+    SECTION("Unpaired single-path read alignment with 8 bp partial match limit finds no extraneous paths") {
         AlignmentPathFinder<vg::Alignment> alignment_path_finder(paths_index, "unstranded", true, false, 1000, 8, true, 20, 0);
         auto alignment_paths = alignment_path_finder.findAlignmentPaths(alignment_1);
         REQUIRE(alignment_paths.size() == 2);


### PR DESCRIPTION
Now `--max-par-offset` is allowed to apply at both the start *and* the end of a read, at the same time. So a haplotype match no longer has to abut at least one end of the read.